### PR TITLE
fix: deploy-infra sequential after container-test, unique deploymentName

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -209,8 +209,8 @@ jobs:
           exit 1
 
   deploy-infra:
-    name: Deploy Infrastructure (Bicep)
-    needs: build-push-amd64
+    name: deploy-infra
+    needs: container-test
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -235,6 +235,7 @@ jobs:
           template: infra/main.bicep
           parameters: infra/main.bicepparam
           deploymentMode: Incremental
+          deploymentName: cpnucleo-infra
 
   merge-manifest:
     name: Merge Multi-arch Manifest (${{ matrix.service }})
@@ -269,7 +270,7 @@ jobs:
 
   deploy-image:
     name: Deploy to Azure (${{ matrix.service }})
-    needs: [container-test, deploy-infra]
+    needs: deploy-infra
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

- **Job name**: `Deploy Infrastructure (Bicep)` → `deploy-infra`
- **Dependency**: `needs: build-push-amd64` → `needs: container-test` — infra deploys only after healthchecks pass, creating a clean linear flow
- **deploy-image**: `needs: [container-test, deploy-infra]` → `needs: deploy-infra` (container-test is implied upstream)
- **deploymentName: cpnucleo-infra** — fixes `DeploymentActive` conflict when cpnucleo and blazor-mudblazor pipelines fire simultaneously in the same resource group (both were defaulting to deployment name `main`)

## New pipeline flow

```
setup-build-test (x4)
        │
        ▼
build-push-amd64 (x4) ──────────────────────────┐
        │                                        │
        ▼                                        ▼
container-test (x4)                    build-push-arm64 (x4)
        │                                        │
        ▼                                        ▼
deploy-infra                            merge-manifest (x4)
        │
        ▼
deploy-image (x4)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)