### PR TITLE
feat: enable HTTP/2 proxy for cpnucleo-grpc-server

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -100,6 +100,7 @@ module grpcServerApp 'modules/webApp.bicep' = {
     appInsightsConnectionString: appInsightsGrpcServer.outputs.connectionString
     appInsightsInstrumentationKey: appInsightsGrpcServer.outputs.instrumentationKey
     projectName: projectName
+    http20ProxyFlag: 1 // required for end-to-end gRPC (HTTP/2 proxy)
   }
 }
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "8264433484234391200"
+      "templateHash": "2198157514563441332"
     }
   },
   "parameters": {
@@ -608,7 +608,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "7264439817585079344"
+              "templateHash": "5537484073317814241"
             }
           },
           "parameters": {
@@ -632,6 +632,13 @@
             },
             "projectName": {
               "type": "string"
+            },
+            "http20ProxyFlag": {
+              "type": "int",
+              "defaultValue": 0,
+              "metadata": {
+                "description": "Enable HTTP/2 proxy for end-to-end gRPC support. Required for gRPC services."
+              }
             }
           },
           "resources": [
@@ -651,6 +658,7 @@
                   "linuxFxVersion": "[format('DOCKER|{0}', parameters('containerImage'))]",
                   "alwaysOn": false,
                   "http20Enabled": true,
+                  "http20ProxyFlag": "[parameters('http20ProxyFlag')]",
                   "minTlsVersion": "1.2",
                   "ftpsState": "Disabled",
                   "appSettings": [
@@ -726,6 +734,9 @@
           },
           "projectName": {
             "value": "[parameters('projectName')]"
+          },
+          "http20ProxyFlag": {
+            "value": 1
           }
         },
         "template": {
@@ -735,7 +746,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "7264439817585079344"
+              "templateHash": "5537484073317814241"
             }
           },
           "parameters": {
@@ -759,6 +770,13 @@
             },
             "projectName": {
               "type": "string"
+            },
+            "http20ProxyFlag": {
+              "type": "int",
+              "defaultValue": 0,
+              "metadata": {
+                "description": "Enable HTTP/2 proxy for end-to-end gRPC support. Required for gRPC services."
+              }
             }
           },
           "resources": [
@@ -778,6 +796,7 @@
                   "linuxFxVersion": "[format('DOCKER|{0}', parameters('containerImage'))]",
                   "alwaysOn": false,
                   "http20Enabled": true,
+                  "http20ProxyFlag": "[parameters('http20ProxyFlag')]",
                   "minTlsVersion": "1.2",
                   "ftpsState": "Disabled",
                   "appSettings": [
@@ -862,7 +881,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "7264439817585079344"
+              "templateHash": "5537484073317814241"
             }
           },
           "parameters": {
@@ -886,6 +905,13 @@
             },
             "projectName": {
               "type": "string"
+            },
+            "http20ProxyFlag": {
+              "type": "int",
+              "defaultValue": 0,
+              "metadata": {
+                "description": "Enable HTTP/2 proxy for end-to-end gRPC support. Required for gRPC services."
+              }
             }
           },
           "resources": [
@@ -905,6 +931,7 @@
                   "linuxFxVersion": "[format('DOCKER|{0}', parameters('containerImage'))]",
                   "alwaysOn": false,
                   "http20Enabled": true,
+                  "http20ProxyFlag": "[parameters('http20ProxyFlag')]",
                   "minTlsVersion": "1.2",
                   "ftpsState": "Disabled",
                   "appSettings": [
@@ -989,7 +1016,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "7264439817585079344"
+              "templateHash": "5537484073317814241"
             }
           },
           "parameters": {
@@ -1013,6 +1040,13 @@
             },
             "projectName": {
               "type": "string"
+            },
+            "http20ProxyFlag": {
+              "type": "int",
+              "defaultValue": 0,
+              "metadata": {
+                "description": "Enable HTTP/2 proxy for end-to-end gRPC support. Required for gRPC services."
+              }
             }
           },
           "resources": [
@@ -1032,6 +1066,7 @@
                   "linuxFxVersion": "[format('DOCKER|{0}', parameters('containerImage'))]",
                   "alwaysOn": false,
                   "http20Enabled": true,
+                  "http20ProxyFlag": "[parameters('http20ProxyFlag')]",
                   "minTlsVersion": "1.2",
                   "ftpsState": "Disabled",
                   "appSettings": [

--- a/infra/modules/webApp.bicep
+++ b/infra/modules/webApp.bicep
@@ -6,6 +6,9 @@ param appInsightsConnectionString string
 param appInsightsInstrumentationKey string
 param projectName string
 
+@description('Enable HTTP/2 proxy for end-to-end gRPC support. Required for gRPC services.')
+param http20ProxyFlag int = 0
+
 resource webApp 'Microsoft.Web/sites@2024-04-01' = {
   name: webAppName
   location: location
@@ -20,6 +23,8 @@ resource webApp 'Microsoft.Web/sites@2024-04-01' = {
       linuxFxVersion: 'DOCKER|${containerImage}'
       alwaysOn: false // must be false on F1
       http20Enabled: true
+      #disable-next-line BCP037 // valid ARM property, not yet in Bicep type library
+      http20ProxyFlag: http20ProxyFlag
       minTlsVersion: '1.2'
       ftpsState: 'Disabled'
       appSettings: [


### PR DESCRIPTION
## Summary

- `infra/modules/webApp.bicep` — adds `http20ProxyFlag` param (default `0`); sets it alongside `http20Enabled` in `siteConfig`
- `infra/main.bicep` — passes `http20ProxyFlag: 1` only for `grpcServerApp`; all other services keep the default `0`

`http20ProxyFlag` is a valid ARM property (confirmed via `az webapp config show`) not yet reflected in the Bicep type library — suppressed with `#disable-next-line BCP037`.

## Why

gRPC requires HTTP/2 to be preserved end-to-end. Azure App Service's HTTP/2 Proxy toggle (`http20ProxyFlag: 1`) enables that for the grpc-server app. Previously only `http20Enabled: true` was set (client → App Service), but not the proxy leg (App Service → container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)