### PR TITLE
docs: add full SEO metadata to GitHub Pages site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,45 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>cpnucleo | Enterprise .NET Architecture</title>
+  <meta name="description" content="Production-grade .NET 10 project management system built with Clean Architecture, CQRS, and DDD. 55 REST endpoints + 55 gRPC handlers. Blazor WebClient deployed on Azure.">
+  <meta name="keywords" content=".NET 10, Clean Architecture, CQRS, DDD, microservices, ASP.NET Core, Blazor, Azure, gRPC, PostgreSQL, C#, FastEndpoints">
+  <link rel="canonical" href="https://jonathanperis.github.io/cpnucleo/">
+  <meta name="theme-color" content="#00d4ff">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="cpnucleo | Enterprise .NET Architecture">
+  <meta property="og:description" content="Production-grade .NET 10 project management system built with Clean Architecture, CQRS, and DDD. 55 REST endpoints + 55 gRPC handlers. Blazor WebClient deployed on Azure.">
+  <meta property="og:url" content="https://jonathanperis.github.io/cpnucleo/">
+  <meta property="og:site_name" content="cpnucleo">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="cpnucleo | Enterprise .NET Architecture">
+  <meta name="twitter:description" content="Production-grade .NET 10 project management system built with Clean Architecture, CQRS, and DDD. 55 REST endpoints + 55 gRPC handlers.">
+  <meta name="twitter:creator" content="@jperis_silva">
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "name": "cpnucleo",
+    "description": "Production-grade .NET 10 project management system built with Clean Architecture, CQRS, and DDD. 55 REST endpoints + 55 gRPC handlers. Blazor WebClient deployed on Azure.",
+    "url": "https://jonathanperis.github.io/cpnucleo/",
+    "codeRepository": "https://github.com/jonathanperis/cpnucleo",
+    "programmingLanguage": "C#",
+    "runtimePlatform": ".NET 10",
+    "license": "https://github.com/jonathanperis/cpnucleo/blob/main/LICENSE",
+    "author": {
+      "@type": "Person",
+      "name": "Jonathan Peris",
+      "url": "https://jonathanperis.github.io/"
+    }
+  }
+  </script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://jonathanperis.github.io/cpnucleo/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://jonathanperis.github.io/cpnucleo/</loc>
+    <lastmod>2026-04-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Add `meta description`, `keywords`, `canonical`, `theme-color` to `docs/index.html`
- Add Open Graph and Twitter Card tags for social previews
- Add JSON-LD `SoftwareSourceCode` structured data for rich search results
- Create `docs/robots.txt` and `docs/sitemap.xml`

## Test plan
- [ ] Verify page renders correctly at https://jonathanperis.github.io/cpnucleo/
- [ ] Check OG tags with https://opengraph.io or Twitter Card Validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)