### PR TITLE
fix(docs): open Azure live demo links in a new tab

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -698,7 +698,7 @@
     <nav>
       <div class="logo">cpnucleo</div>
       <div class="nav-links">
-        <a href="https://cpnucleo-webclient-dotnet-d6gve6cabpefbmfz.brazilsouth-01.azurewebsites.net/">Live Demo</a>
+        <a href="https://cpnucleo-webclient-dotnet-d6gve6cabpefbmfz.brazilsouth-01.azurewebsites.net/" target="_blank" rel="noopener noreferrer">Live Demo</a>
         <a href="./docs/">Documentation</a>
         <a href="https://github.com/jonathanperis/cpnucleo">GitHub</a>
       </div>
@@ -712,7 +712,7 @@
           A production-ready blueprint demonstrating Clean Architecture and Domain-Driven Design. Featuring a dual transport layer (REST API + gRPC) powered by Blazor and PostgreSQL.
         </p>
         <div class="ctas">
-          <a href="https://cpnucleo-webclient-dotnet-d6gve6cabpefbmfz.brazilsouth-01.azurewebsites.net/" class="cta cta-primary">🔴 Try it Live →</a>
+          <a href="https://cpnucleo-webclient-dotnet-d6gve6cabpefbmfz.brazilsouth-01.azurewebsites.net/" target="_blank" rel="noopener noreferrer" class="cta cta-primary">🔴 Try it Live →</a>
           <a href="./docs/" class="cta cta-secondary">📖 View Documentation →</a>
           <a href="https://github.com/jonathanperis/cpnucleo" class="cta cta-secondary">⚙ View on GitHub →</a>
         </div>
@@ -783,7 +783,7 @@
 
     <footer>
       <div class="footer-links">
-        <a href="https://cpnucleo-webclient-dotnet-d6gve6cabpefbmfz.brazilsouth-01.azurewebsites.net/">Live Demo</a>
+        <a href="https://cpnucleo-webclient-dotnet-d6gve6cabpefbmfz.brazilsouth-01.azurewebsites.net/" target="_blank" rel="noopener noreferrer">Live Demo</a>
         <a href="./docs/">Documentation</a>
         <a href="https://github.com/jonathanperis/cpnucleo">GitHub Repository</a>
       </div>


### PR DESCRIPTION
## Summary
- Add `target="_blank" rel="noopener noreferrer"` to all 3 Azure live demo links in `docs/index.html` (nav, hero CTA, footer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)