### PR TITLE
ci(dependabot): scan src/* and test/* projects + add groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,38 @@
 version: 2
 updates:
+  # NuGet — scan every project under src/ and test/
   - package-ecosystem: "nuget"
-    directory: "/"
+    directories:
+      - "/"
+      - "/src/Domain"
+      - "/src/GrpcServer"
+      - "/src/GrpcServer.Contracts"
+      - "/src/IdentityApi"
+      - "/src/Infrastructure"
+      - "/src/WebApi"
+      - "/src/WebApi.Client"
+      - "/src/WebClient"
+      - "/test/Architecture.Tests"
+      - "/test/WebApi.Integration.Tests"
+      - "/test/WebApi.Unit.Tests"
     schedule:
       interval: "weekly"
+    groups:
+      microsoft:
+        patterns:
+          - "Microsoft.*"
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry.*"
+      testing:
+        patterns:
+          - "xunit*"
+          - "FluentAssertions*"
+          - "coverlet.*"
+          - "Moq*"
+          - "Microsoft.NET.Test.*"
+
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Switch `directory: "/"` → `directories: [...]` listing every src/ and test/ project explicitly
- Add update groups (`microsoft`, `opentelemetry`, `testing`) so multi-package bumps land grouped

## Why
The audit identified **8 open OpenTelemetry Dependabot alerts** in this repo (4 projects × 2 advisories) with no auto-PR. Root cause: the previous config only scanned `/`, never reaching the `.csproj` files in `src/<project>/` and `test/<project>/`.

Affected advisories:
- [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) — OpenTelemetry.Exporter.OpenTelemetryProtocol unbounded HTTP response bodies (fix: 1.15.2)
- [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) — OpenTelemetry.Exporter.OpenTelemetryProtocol unbounded grpc-status-details-bin parsing (fix: 1.15.3)

## Effect
- Dependabot will scan all 11 NuGet manifests on its next pass and open security PRs for the OTel advisories
- Future weekly version bumps land grouped (one PR per group) instead of one per .csproj — should reduce PR noise

## Test plan
- [ ] Merge → wait for next Dependabot pass
- [ ] Verify OTel security PR(s) opened in this repo
- [ ] Confirm grouped weekly PRs land as expected on next weekly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)