### PR TITLE
chore(deps): bump OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.0 → 1.15.3

### DIFF
--- a/src/GrpcServer/GrpcServer.csproj
+++ b/src/GrpcServer/GrpcServer.csproj
@@ -45,7 +45,7 @@
     
     <ItemGroup>
 		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/src/IdentityApi/IdentityApi.csproj
+++ b/src/IdentityApi/IdentityApi.csproj
@@ -51,7 +51,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -54,7 +54,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/src/WebClient/WebClient.csproj
+++ b/src/WebClient/WebClient.csproj
@@ -43,7 +43,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />


### PR DESCRIPTION
## Summary
Manual security bump fixing **8 open Dependabot alerts** (2 advisories × 4 projects):

- [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) (moderate) — unbounded HTTP response bodies in OTLP exporter, fix `1.15.2`
- [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) (moderate) — unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling, fix `1.15.3`

Bumping past `1.15.3` resolves both.

## Files
- `src/GrpcServer/GrpcServer.csproj`
- `src/IdentityApi/IdentityApi.csproj`
- `src/WebApi/WebApi.csproj`
- `src/WebClient/WebClient.csproj`

## Why manual?
Dependabot wasn't auto-opening these PRs because the previous config scanned only `/` (root). PR #169 expanded the scan scope, but Dependabot's first re-scan can take some time. Doing the bump by hand to clear the alerts now.

## Test plan
- [ ] CI passes (full Setup/Build/Test on all 4 services)
- [ ] After merge, alerts auto-dismiss as fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)