### PR TITLE
chore: suppress CodeQL cs/class-name-matches-base-class rule

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,3 +4,6 @@ paths-ignore:
   - 'src/**/bin/**'
   - '**/*.g.cs'
   - '**/*.designer.cs'
+query-filters:
+  - exclude:
+      id: cs/class-name-matches-base-class


### PR DESCRIPTION
## Summary
- Suppress `cs/class-name-matches-base-class` CodeQL rule via `query-filters` in `codeql-config.yml`
- 11 open alerts (all note-level) caused by nested `Validator` classes inheriting from base `Validator` — intentional FastEndpoints convention
- No security impact; purely a naming quality rule

## Why
The `Remove*Request.Validator` pattern is by design across all Remove endpoints. Renaming would break FastEndpoints auto-discovery conventions. Suppression is the correct resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis configuration to refine scanning rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->