### PR TITLE
fix: exclude false-positive CodeQL rules

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,3 +4,6 @@ paths-ignore:
   - 'src/**/bin/**'
   - '**/*.g.cs'
   - '**/*.designer.cs'
+query-filters:
+  - exclude:
+      id: cs/class-name-matches-base-class

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,5 +9,10 @@ query-filters:
       id: cs/class-name-matches-base-class
   - exclude:
       id: cs/catch-of-all-exceptions
+      paths:
+        - 'src/WebApi/Middlewares/ErrorHandlingMiddleware.cs'
+        - 'src/IdentityApi/Middlewares/ErrorHandlingMiddleware.cs'
   - exclude:
       id: cs/path-combine
+      paths:
+        - 'src/Infrastructure/Common/Helpers/FakeData.cs'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -7,3 +7,7 @@ paths-ignore:
 query-filters:
   - exclude:
       id: cs/class-name-matches-base-class
+  - exclude:
+      id: cs/catch-of-all-exceptions
+  - exclude:
+      id: cs/path-combine


### PR DESCRIPTION
## Summary

- Dismissed alerts #69 and #70 as false positives
- Added `query-filters` to `.github/codeql/codeql-config.yml` to exclude `cs/catch-of-all-exceptions` and `cs/path-combine`, preventing recurrence

## Context

**#70** — `cs/catch-of-all-exceptions` in `ErrorHandlingMiddleware.cs`: intentional middleware boundary catch-all to prevent unhandled exception leakage to clients. Already has `#pragma warning disable CA1031`.

**#69** — `cs/path-combine` in `FakeData.cs`: `Path.Combine("dml-data", Path.GetFileName(fileName))` — `Path.GetFileName` strips directory components, making an absolute path (which would drop earlier args) impossible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL configuration to exclude specific C# analysis queries (including class-name, catch-all exception, and path-combine checks).
  * Scoped those exclusions to targeted areas of the codebase to reduce noise from false positives during scans.
  * Configuration-only change; no exported/public APIs or declarations were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->