### PR TITLE
chore: remove wiki/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -489,7 +489,6 @@ dml-data
 003-database-dump-csv-dml.sql
 
 # Docs generation
-wiki/
 package-lock.json
 # Allow the docs Astro project to commit its lockfile and env
 !docs/package-lock.json


### PR DESCRIPTION
Allow wiki/ folder to be tracked. PR #182 should be merged first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git configuration to track additional project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->