### PR TITLE
fix(docs): extract SECTION_CATEGORIES to sidebar.config.ts for Astro hoisting

### DIFF
--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -1,12 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import '../../styles/docs.css';
-
-const SECTION_CATEGORIES = [
-  { label: '', ids: ['home'] },
-  { label: 'Overview', ids: ['architecture', 'api-reference', 'database'] },
-  { label: 'Develop', ids: ['getting-started', 'project-structure', 'technologies', 'testing', 'deployment'] },
-];
+import { SECTION_CATEGORIES, SECTION_ORDER } from './sidebar.config';
 
 const SLUG_LABEL: Record<string, string> = {
   home: 'Home',
@@ -28,6 +23,19 @@ for (const [path, module] of Object.entries(globResult)) {
   pagesBySlug[fileName] = module;
 }
 
+// Build-time assertion: validate SECTION_CATEGORIES IDs against discovered slugs
+const availableSlugs = new Set(Object.keys(pagesBySlug));
+for (const cat of SECTION_CATEGORIES) {
+  for (const id of cat.ids) {
+    if (!availableSlugs.has(id)) {
+      const catName = cat.label || 'root';
+      throw new Error(
+        `SECTION_CATEGORIES references id "${id}" (category: "${catName}") but no matching wiki/${id}.md was found. Available slugs: ${Array.from(availableSlugs).join(', ')}`
+      );
+    }
+  }
+}
+
 const requestedSlug = Astro.params.slug;
 const isRoot = requestedSlug === undefined;
 const requestedKey = requestedSlug ?? 'home';
@@ -43,10 +51,9 @@ const sectionsToRender = isRoot
     })();
 
 export function getStaticPaths() {
-  const order = ['home', 'architecture', 'api-reference', 'database', 'getting-started', 'project-structure', 'technologies', 'testing', 'deployment'];
   return [
     { params: { slug: undefined } },
-    ...order.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
+    ...SECTION_ORDER.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
   ];
 }
 

--- a/docs/src/pages/docs/sidebar.config.ts
+++ b/docs/src/pages/docs/sidebar.config.ts
@@ -1,0 +1,7 @@
+export const SECTION_CATEGORIES = [
+  { label: "", ids: ["home"] },
+  { label: "Overview", ids: ["architecture", "api-reference", "database"] },
+  { label: "Develop", ids: ["getting-started", "project-structure", "technologies", "testing", "deployment"] },
+] as const;
+
+export const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);


### PR DESCRIPTION
## Summary
- Fix `SECTION_ORDER is not defined` build error — Astro hoists `getStaticPaths`, only imports survive
- Extract `SECTION_CATEGORIES` + `SECTION_ORDER` to `sidebar.config.ts`
- Add build-time assertion validating category IDs against wiki slugs
- Replace hardcoded `order` array in `getStaticPaths()` with imported `SECTION_ORDER`

## Files
- `docs/src/pages/docs/sidebar.config.ts` (new)
- `docs/src/pages/docs/[...slug].astro` (import + remove inline def + update getStaticPaths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation structure and organization with centralized configuration for sidebar sections.

* **Chores**
  * Enhanced documentation build validation to ensure consistency between configuration and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->