### PR TITLE
fix(docs): exclude .astro-code from pre/code CSS rules

### DIFF
--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -1,12 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import '../../styles/docs.css';
-
-const SECTION_CATEGORIES = [
-  { label: '', ids: ['home'] },
-  { label: 'Overview', ids: ['architecture', 'api-reference', 'database'] },
-  { label: 'Develop', ids: ['getting-started', 'project-structure', 'technologies', 'testing', 'deployment'] },
-];
+import { SECTION_CATEGORIES, SECTION_ORDER } from './sidebar.config';
 
 const SLUG_LABEL: Record<string, string> = {
   home: 'Home',
@@ -28,6 +23,19 @@ for (const [path, module] of Object.entries(globResult)) {
   pagesBySlug[fileName] = module;
 }
 
+// Build-time assertion: validate SECTION_CATEGORIES IDs against discovered slugs
+const availableSlugs = new Set(Object.keys(pagesBySlug));
+for (const cat of SECTION_CATEGORIES) {
+  for (const id of cat.ids) {
+    if (!availableSlugs.has(id)) {
+      const catName = cat.label || 'root';
+      throw new Error(
+        `SECTION_CATEGORIES references id "${id}" (category: "${catName}") but no matching wiki/${id}.md was found. Available slugs: ${Array.from(availableSlugs).join(', ')}`
+      );
+    }
+  }
+}
+
 const requestedSlug = Astro.params.slug;
 const isRoot = requestedSlug === undefined;
 const requestedKey = requestedSlug ?? 'home';
@@ -43,10 +51,9 @@ const sectionsToRender = isRoot
     })();
 
 export function getStaticPaths() {
-  const order = ['home', 'architecture', 'api-reference', 'database', 'getting-started', 'project-structure', 'technologies', 'testing', 'deployment'];
   return [
     { params: { slug: undefined } },
-    ...order.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
+    ...SECTION_ORDER.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
   ];
 }
 

--- a/docs/src/pages/docs/sidebar.config.ts
+++ b/docs/src/pages/docs/sidebar.config.ts
@@ -1,0 +1,7 @@
+export const SECTION_CATEGORIES = [
+  { label: "", ids: ["home"] },
+  { label: "Overview", ids: ["architecture", "api-reference", "database"] },
+  { label: "Develop", ids: ["getting-started", "project-structure", "technologies", "testing", "deployment"] },
+] as const;
+
+export const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -245,7 +245,7 @@ a {
 }
 a:hover { text-decoration: underline; }
 
-pre {
+pre:not(.astro-code) {
   background: var(--code-bg);
   border: 1px solid var(--code-border);
   border-radius: 8px;
@@ -253,12 +253,18 @@ pre {
   overflow-x: auto;
   margin: 24px 0;
 }
-pre code {
+pre:not(.astro-code) code {
   background: transparent;
   padding: 0;
   border-radius: 0;
   color: var(--code-text);
   font-size: 13px;
+}
+pre.astro-code {
+  border: 1px solid var(--code-border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin: 24px 0;
 }
 code {
   background: var(--code-bg);


### PR DESCRIPTION
## Problem\nCode blocks with syntax highlighting appear blank on deployed docs sites.\n\n## Root Cause\ndocs.css has pre { background: var(--code-bg) } and pre code { color: var(--code-text) } which override Astro/Shiki inline styles on pre.astro-code elements.\n\n## Fix\nChanged CSS selectors to pre:not(.astro-code) to preserve Shiki syntax highlighting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved code block styling in documentation pages for better visual distinction.

* **Chores**
  * Enhanced documentation configuration with improved organization and build-time validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->