### PR TITLE
fix: force code block text visibility

### DIFF
--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -261,6 +261,8 @@ pre:not(.astro-code) code {
   font-size: 13px;
 }
 pre.astro-code {
+  background-color: inherit;
+  color: inherit;
   border: 1px solid var(--code-border);
   border-radius: 8px;
   padding: 16px 20px;


### PR DESCRIPTION
## Summary
- Add explicit `color: inherit` to `pre.astro-code` CSS rule
- Ensures inline Shiki styles (`style="color:#e1e4e8"`) are not overridden by inherited styles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code block styling to inherit background and text colors from surrounding elements for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->