### PR TITLE
fix(docs): restore code block text

### DIFF
--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -350,14 +350,14 @@ main {
 .n-grpc{ top: 150px; right: 0;  width: 150px; }
 .n-app { top: 310px; left: 50%; transform: translateX(-50%); width: 90%; }
 
-.line {
+.hero-diagram .line {
   position: absolute;
   background: var(--accent-dark);
   z-index: -1;
   overflow: hidden;
 }
 
-.line::after {
+.hero-diagram .line::after {
   content: '';
   position: absolute;
   top: 0; left: 0;
@@ -366,10 +366,10 @@ main {
   animation: drawLine 2s infinite linear;
 }
 
-.l-1 { top: 80px; left: 35%;  width: 2px; height: 70px; }
-.l-2 { top: 80px; right: 35%; width: 2px; height: 70px; }
-.l-3 { top: 230px; left: 22%; width: 2px; height: 80px; }
-.l-4 { top: 230px; right: 22%; width: 2px; height: 80px; }
+.hero-diagram .l-1 { top: 80px; left: 35%;  width: 2px; height: 70px; }
+.hero-diagram .l-2 { top: 80px; right: 35%; width: 2px; height: 70px; }
+.hero-diagram .l-3 { top: 230px; left: 22%; width: 2px; height: 80px; }
+.hero-diagram .l-4 { top: 230px; right: 22%; width: 2px; height: 80px; }
 
 @keyframes drawLine {
   0%   { transform: translateY(-100%); }


### PR DESCRIPTION
## Summary
- Scope homepage diagram `.line` CSS so it no longer affects Shiki code block line spans.
- Restores visible code text in generated docs code samples.

## Validation
- `bun run build`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Scoped decorative diagram styling to prevent potential conflicts with other elements on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->