### PR TITLE
fix(docs): clean code block highlights

### DIFF
--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -253,7 +253,7 @@ pre:not(.astro-code) {
   overflow-x: auto;
   margin: 24px 0;
 }
-pre:not(.astro-code) code {
+pre:not(.astro-code) > code {
   background: transparent;
   padding: 0;
   border-radius: 0;
@@ -268,7 +268,13 @@ pre.astro-code {
   padding: 16px 20px;
   margin: 24px 0;
 }
-code {
+pre.astro-code > code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+}
+:not(pre) > code {
   background: var(--code-bg);
   color: var(--code-text);
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- Keep inline code chip styling out of fenced code blocks.
- Reset Shiki `<pre><code>` content so code samples render without per-line highlight boxes.

## Validation
- `bun run build`
- `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined code block and inline code styling in documentation for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->