### PR TITLE
chore: prepare Hostinger production deployment

### DIFF
--- a/.env.hostinger.example
+++ b/.env.hostinger.example
@@ -1,0 +1,55 @@
+# Copy this file to .env on the Hostinger VPS and fill real secrets there.
+# Do not commit the real .env file.
+
+# ---------- Public URLs ----------
+# Recommended public shape behind Traefik:
+#   https://cpnucleo.jonathanperis.tech          -> WebClient
+#   https://api-cpnucleo.jonathanperis.tech      -> REST API through internal NGINX LB
+#   https://identity-cpnucleo.jonathanperis.tech -> Identity API
+#   https://grpc-cpnucleo.jonathanperis.tech     -> gRPC server, HTTP/2 h2c behind Traefik
+CPNUCLEO_WEB_HOST=cpnucleo.jonathanperis.tech
+CPNUCLEO_API_HOST=api-cpnucleo.jonathanperis.tech
+CPNUCLEO_IDENTITY_HOST=identity-cpnucleo.jonathanperis.tech
+CPNUCLEO_GRPC_HOST=grpc-cpnucleo.jonathanperis.tech
+
+# Frontend/API configuration. ASP.NET Core maps __ to configuration sections/keys.
+WebApiBaseUrl=https://api-cpnucleo.jonathanperis.tech
+
+# ---------- Traefik ----------
+# Must match the external Docker network used by /docker/traefik.
+TRAEFIK_NETWORK=traefik
+TRAEFIK_CERT_RESOLVER=letsencrypt
+
+# ---------- Immutable runtime images ----------
+# Replace sha-REPLACE_ME with the exact immutable tag produced by the release pipeline.
+# Avoid :latest in production so rollbacks are deterministic.
+CPNUCLEO_WEB_API_IMAGE=ghcr.io/jonathanperis/cpnucleo-web-api:sha-REPLACE_ME
+CPNUCLEO_IDENTITY_API_IMAGE=ghcr.io/jonathanperis/cpnucleo-identity-api:sha-REPLACE_ME
+CPNUCLEO_GRPC_SERVER_IMAGE=ghcr.io/jonathanperis/cpnucleo-grpc-server:sha-REPLACE_ME
+CPNUCLEO_WEB_CLIENT_IMAGE=ghcr.io/jonathanperis/cpnucleo-web-client:sha-REPLACE_ME
+
+# ---------- Runtime ----------
+ASPNETCORE_ENVIRONMENT=Production
+ASPNETCORE_FORWARDEDHEADERS_ENABLED=true
+
+# ---------- PostgreSQL ----------
+POSTGRES_USER=cpnucleo
+POSTGRES_PASSWORD=CHANGE_ME_LONG_RANDOM_PASSWORD
+POSTGRES_DB=cpnucleo
+DB_CONNECTION_STRING=Host=db;Port=5432;Database=cpnucleo;Username=cpnucleo;Password=CHANGE_ME_LONG_RANDOM_PASSWORD;Pooling=true;Maximum Pool Size=100;Include Error Detail=false
+
+# ---------- Identity / JWT ----------
+# Generate with: openssl rand -base64 64
+Jwt__SigningKey=CHANGE_ME_BASE64_OR_LONG_RANDOM_SECRET_AT_LEAST_32_CHARS
+
+# ---------- Observability ----------
+# Leave empty to disable App Insights exporter on Hostinger, or set if you keep Azure Monitor.
+APPLICATIONINSIGHTS_CONNECTION_STRING=
+# Optional local/remote OTLP endpoint if you add an observability stack.
+OTEL_ENDPOINT=
+OTEL_METRIC_EXPORT_INTERVAL=30000
+
+# ---------- Backups ----------
+# Used by scripts/backup-hostinger.sh.
+BACKUP_DIR=/opt/backups/cpnucleo
+BACKUP_RETENTION_DAYS=14

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -96,7 +96,9 @@ jobs:
           context: ./src/
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ matrix.image }}:latest
+          tags: |
+            ${{ matrix.image }}:sha-${{ github.sha }}-amd64
+            ${{ matrix.image }}:latest
           platforms: linux/amd64
           build-args: |
             AOT=${{ env.AOT }}
@@ -152,7 +154,9 @@ jobs:
           context: ./src/
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ matrix.image }}:latest-arm64
+          tags: |
+            ${{ matrix.image }}:sha-${{ github.sha }}-arm64
+            ${{ matrix.image }}:latest-arm64
           platforms: linux/arm64/v8
           build-args: |
             AOT=${{ env.AOT }}
@@ -189,7 +193,7 @@ jobs:
 
       - name: Build and Run Docker Compose for Healthcheck Test
         run: |
-          docker compose -f compose.prod.yaml up ${{ matrix.compose_service }} -d --no-deps
+          docker compose up ${{ matrix.compose_service }} -d --no-deps
           sleep 30
 
       - name: Test Healthcheck Endpoint
@@ -264,13 +268,14 @@ jobs:
       - name: Merge into multi-arch manifest
         run: |
           docker buildx imagetools create \
+            --tag ${{ matrix.image }}:sha-${{ github.sha }} \
             --tag ${{ matrix.image }}:latest \
-            ${{ matrix.image }}:latest \
-            ${{ matrix.image }}:latest-arm64
+            ${{ matrix.image }}:sha-${{ github.sha }}-amd64 \
+            ${{ matrix.image }}:sha-${{ github.sha }}-arm64
 
   deploy-image:
     name: Deploy to Azure (${{ matrix.service }})
-    needs: deploy-infra
+    needs: [deploy-infra, merge-manifest]
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -279,16 +284,16 @@ jobs:
         include:
           - service: WebApi
             app-name: cpnucleo-api-dotnet
-            image: ghcr.io/jonathanperis/cpnucleo-web-api:latest
+            image: ghcr.io/jonathanperis/cpnucleo-web-api:sha-${{ github.sha }}
           - service: GrpcServer
             app-name: cpnucleo-grpc-server
-            image: ghcr.io/jonathanperis/cpnucleo-grpc-server:latest
+            image: ghcr.io/jonathanperis/cpnucleo-grpc-server:sha-${{ github.sha }}
           - service: IdentityApi
             app-name: cpnucleo-identity-api
-            image: ghcr.io/jonathanperis/cpnucleo-identity-api:latest
+            image: ghcr.io/jonathanperis/cpnucleo-identity-api:sha-${{ github.sha }}
           - service: WebClient
             app-name: cpnucleo-webclient-dotnet
-            image: ghcr.io/jonathanperis/cpnucleo-web-client:latest
+            image: ghcr.io/jonathanperis/cpnucleo-web-client:sha-${{ github.sha }}
 
     steps:
       - name: Login to Azure (OIDC)

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,6 +1,10 @@
 name: "cpnucleo-prod"
 
-# Consolidated common healthcheck configurations.
+# Hostinger production profile.
+# Public traffic is terminated by the existing Traefik stack on the external
+# network below. Application/database ports stay private to Docker networks.
+# Minimum VPS: 2 vCPU / 4 GiB RAM. Recommended VPS: 4 vCPU / 8 GiB RAM.
+
 x-common-healthcheck:
   x-healthcheck-api: &healthcheck-api
     test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
@@ -23,7 +27,6 @@ x-common-healthcheck:
     timeout: 10s
     retries: 3
 
-# Extension defining common API configuration for production.
 x-common-api-prod: &common-api-prod
   depends_on:
     db:
@@ -38,9 +41,8 @@ x-common-api-prod: &common-api-prod
         memory: "512M"
       reservations:
         cpus: "0.25"
-        memory: "256M"    
+        memory: "256M"
 
-# Common logging options for production services.
 x-common-logging: &common-logging
   logging:
     driver: "json-file"
@@ -51,51 +53,79 @@ x-common-logging: &common-logging
 services:
   webapi1-cpnucleo: &webapi1
     <<: [*common-api-prod, *common-logging]
-    image: ghcr.io/jonathanperis/cpnucleo-web-api:latest
+    image: ${CPNUCLEO_WEB_API_IMAGE:?Set CPNUCLEO_WEB_API_IMAGE to an immutable GHCR tag, not latest}
     container_name: webapi1-cpnucleo
-    ports:
-      # Production port mapping: host port 5100 is forwarded to container port 5000
-      - "5100:5000"
+    expose:
+      - "5000"
     healthcheck: *healthcheck-api
 
   webapi2-cpnucleo:
     <<: [*webapi1, *common-api-prod, *common-logging]
     container_name: webapi2-cpnucleo
-    ports:
-      # Production port mapping: host port 5111 is forwarded to container port 5000
-      - "5111:5000"
+    expose:
+      - "5000"
 
   identityapi-cpnucleo:
     <<: [*common-api-prod, *common-logging]
-    image: ghcr.io/jonathanperis/cpnucleo-identity-api:latest
+    image: ${CPNUCLEO_IDENTITY_API_IMAGE:?Set CPNUCLEO_IDENTITY_API_IMAGE to an immutable GHCR tag, not latest}
     container_name: identityapi-cpnucleo
-    ports:
-      # Production port mapping: host port 5200 is forwarded to container port 5010
-      - "5200:5010"
+    expose:
+      - "5010"
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:-traefik}"
+      - "traefik.http.routers.cpnucleo-identity.rule=Host(`${CPNUCLEO_IDENTITY_HOST:?Set CPNUCLEO_IDENTITY_HOST}`)"
+      - "traefik.http.routers.cpnucleo-identity.entrypoints=websecure"
+      - "traefik.http.routers.cpnucleo-identity.tls=true"
+      - "traefik.http.routers.cpnucleo-identity.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
+      - "traefik.http.services.cpnucleo-identity.loadbalancer.server.port=5010"
     healthcheck: *healthcheck-identity
 
   grpcserver-cpnucleo:
     <<: [*common-api-prod, *common-logging]
-    image: ghcr.io/jonathanperis/cpnucleo-grpc-server:latest
+    image: ${CPNUCLEO_GRPC_SERVER_IMAGE:?Set CPNUCLEO_GRPC_SERVER_IMAGE to an immutable GHCR tag, not latest}
     container_name: grpcserver-cpnucleo
-    ports:
-      # Production port mapping: host port 5300 is forwarded to container port 5020
-      - "5300:5020"
-      # Production port mapping: host port 5301 is forwarded to container port 5021
-      - "5301:5021"
+    expose:
+      - "5020"
+      - "5021"
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:-traefik}"
+      - "traefik.http.routers.cpnucleo-grpc.rule=Host(`${CPNUCLEO_GRPC_HOST:?Set CPNUCLEO_GRPC_HOST}`)"
+      - "traefik.http.routers.cpnucleo-grpc.entrypoints=websecure"
+      - "traefik.http.routers.cpnucleo-grpc.tls=true"
+      - "traefik.http.routers.cpnucleo-grpc.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
+      - "traefik.http.services.cpnucleo-grpc.loadbalancer.server.port=5020"
+      - "traefik.http.services.cpnucleo-grpc.loadbalancer.server.scheme=h2c"
     healthcheck: *healthcheck-grpcserver
-    
+
   webclient-cpnucleo:
     <<: [*common-logging]
-    image: ghcr.io/jonathanperis/cpnucleo-web-client:latest
+    image: ${CPNUCLEO_WEB_CLIENT_IMAGE:?Set CPNUCLEO_WEB_CLIENT_IMAGE to an immutable GHCR tag, not latest}
     container_name: webclient-cpnucleo
-    ports:
-      # Production port mapping: host port 5400 is forwarded to container port 5030
-      - "5400:5030"
-    healthcheck: *healthcheck-webclient    
+    expose:
+      - "5030"
+    healthcheck: *healthcheck-webclient
     env_file:
-      - .env      
+      - .env
     restart: always
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:-traefik}"
+      - "traefik.http.routers.cpnucleo-web.rule=Host(`${CPNUCLEO_WEB_HOST:?Set CPNUCLEO_WEB_HOST}`)"
+      - "traefik.http.routers.cpnucleo-web.entrypoints=websecure"
+      - "traefik.http.routers.cpnucleo-web.tls=true"
+      - "traefik.http.routers.cpnucleo-web.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
+      - "traefik.http.services.cpnucleo-web.loadbalancer.server.port=5030"
     deploy:
       resources:
         limits:
@@ -104,27 +134,27 @@ services:
         reservations:
           cpus: "0.25"
           memory: "256M"
-          
+
   db:
     image: postgres:16.7
     container_name: db-cpnucleo
     volumes:
       - db_data:/var/lib/postgresql/data
-      - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
-      retries: 5 
-    ports:
-      # Exposing PostgreSQL port consistently on host and container
-      - "5432:5432"
-    # WARNING: synchronous_commit=0, fsync=0, full_page_writes=0 disable durability for load-test performance. Do NOT use in production with real data.
-    command: postgres -c checkpoint_timeout=600 -c max_wal_size=4096 -c synchronous_commit=0 -c fsync=0 -c full_page_writes=0
+      retries: 5
+    # No host port: PostgreSQL is reachable only by containers on cpnucleo_network.
+    expose:
+      - "5432"
+    # Production-safe settings: keep durability enabled; only tune checkpoint/WAL size.
+    command: postgres -c checkpoint_timeout=600 -c max_wal_size=1024
     restart: always
     deploy:
       resources:
@@ -136,6 +166,8 @@ services:
           memory: "512M"
     <<: *common-logging
 
+  # Kept in production as the internal API load balancer, matching local dev topology.
+  # Traefik owns public TLS/host routing; NGINX only balances webapi1/webapi2.
   nginx:
     image: nginx:1.27-alpine
     container_name: nginx-cpnucleo
@@ -145,9 +177,19 @@ services:
       - webapi1-cpnucleo
       - webapi2-cpnucleo
       - identityapi-cpnucleo
-    ports:
-      # Production mapping: host port 9999 is forwarded to container port 9999 for NGINX
-      - "9999:9999"
+    expose:
+      - "9999"
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_NETWORK:-traefik}"
+      - "traefik.http.routers.cpnucleo-api.rule=Host(`${CPNUCLEO_API_HOST:?Set CPNUCLEO_API_HOST}`)"
+      - "traefik.http.routers.cpnucleo-api.entrypoints=websecure"
+      - "traefik.http.routers.cpnucleo-api.tls=true"
+      - "traefik.http.routers.cpnucleo-api.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
+      - "traefik.http.services.cpnucleo-api.loadbalancer.server.port=9999"
     restart: always
     deploy:
       resources:
@@ -171,3 +213,6 @@ networks:
     driver: bridge
     driver_opts:
       com.example.description: "Default network for cpnucleo services"
+  traefik:
+    name: ${TRAEFIK_NETWORK:-traefik}
+    external: true

--- a/scripts/backup-hostinger.sh
+++ b/scripts/backup-hostinger.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Hostinger backup helper for Cpnucleo.
+# Run from the directory that contains compose.prod.yaml and the production .env:
+#   ./scripts/backup-hostinger.sh
+# Optional cron example:
+#   15 3 * * * cd /docker/cpnucleo && ./scripts/backup-hostinger.sh >> /var/log/cpnucleo-backup.log 2>&1
+
+COMPOSE_FILE=${COMPOSE_FILE:-compose.prod.yaml}
+ENV_FILE=${ENV_FILE:-.env}
+BACKUP_DIR=${BACKUP_DIR:-/opt/backups/cpnucleo}
+BACKUP_RETENTION_DAYS=${BACKUP_RETENTION_DAYS:-14}
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+DEST="${BACKUP_DIR}/${TIMESTAMP}"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Missing ${COMPOSE_FILE}; run this script from the Cpnucleo deploy directory." >&2
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}; production secrets and DB settings are required for backup." >&2
+  exit 1
+fi
+
+mkdir -p "${DEST}"
+chmod 700 "${BACKUP_DIR}" "${DEST}"
+
+# Load POSTGRES_USER/POSTGRES_DB/BACKUP_RETENTION_DAYS/BACKUP_DIR if present.
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+: "${POSTGRES_USER:?POSTGRES_USER must be set in ${ENV_FILE}}"
+: "${POSTGRES_DB:?POSTGRES_DB must be set in ${ENV_FILE}}"
+
+# Database logical dump. Custom format keeps restore flexible:
+#   docker compose -f compose.prod.yaml exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists < dump.pgcustom
+if docker compose -f "${COMPOSE_FILE}" ps --status running db >/dev/null 2>&1; then
+  docker compose -f "${COMPOSE_FILE}" exec -T db \
+    pg_dump -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --format=custom --no-owner --no-acl \
+    > "${DEST}/cpnucleo-db.pgcustom"
+else
+  echo "db service is not running; cannot create pg_dump." >&2
+  exit 1
+fi
+
+# Deployment/config backup. This intentionally includes .env because it is required
+# for disaster recovery; store BACKUP_DIR with restrictive permissions and copy it
+# only to a trusted/private off-server location.
+tar -czf "${DEST}/cpnucleo-config.tar.gz" \
+  "${COMPOSE_FILE}" \
+  "${ENV_FILE}" \
+  nginx.conf \
+  docker-entrypoint-initdb.d \
+  2>/dev/null
+
+sha256sum "${DEST}/cpnucleo-db.pgcustom" "${DEST}/cpnucleo-config.tar.gz" \
+  > "${DEST}/SHA256SUMS"
+
+find "${BACKUP_DIR}" -mindepth 1 -maxdepth 1 -type d -mtime +"${BACKUP_RETENTION_DAYS}" -exec rm -rf {} +
+
+printf 'Cpnucleo backup completed: %s\n' "${DEST}"

--- a/scripts/backup-hostinger.sh
+++ b/scripts/backup-hostinger.sh
@@ -9,10 +9,7 @@ set -Eeuo pipefail
 
 COMPOSE_FILE=${COMPOSE_FILE:-compose.prod.yaml}
 ENV_FILE=${ENV_FILE:-.env}
-BACKUP_DIR=${BACKUP_DIR:-/opt/backups/cpnucleo}
-BACKUP_RETENTION_DAYS=${BACKUP_RETENTION_DAYS:-14}
 TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
-DEST="${BACKUP_DIR}/${TIMESTAMP}"
 
 if [[ ! -f "${COMPOSE_FILE}" ]]; then
   echo "Missing ${COMPOSE_FILE}; run this script from the Cpnucleo deploy directory." >&2
@@ -24,17 +21,74 @@ if [[ ! -f "${ENV_FILE}" ]]; then
   exit 1
 fi
 
-mkdir -p "${DEST}"
-chmod 700 "${BACKUP_DIR}" "${DEST}"
+# Parse only the keys this script needs from dotenv syntax without executing it.
+# This keeps DB_CONNECTION_STRING values with spaces (for example
+# "Maximum Pool Size") from breaking the backup script.
+while IFS=$'\t' read -r key value; do
+  case "${key}" in
+    POSTGRES_USER) DOTENV_POSTGRES_USER=${value} ;;
+    POSTGRES_DB) DOTENV_POSTGRES_DB=${value} ;;
+    BACKUP_DIR) DOTENV_BACKUP_DIR=${value} ;;
+    BACKUP_RETENTION_DAYS) DOTENV_BACKUP_RETENTION_DAYS=${value} ;;
+  esac
+done < <(python3 - "${ENV_FILE}" <<'PY'
+import ast
+import sys
 
-# Load POSTGRES_USER/POSTGRES_DB/BACKUP_RETENTION_DAYS/BACKUP_DIR if present.
-set -a
-# shellcheck disable=SC1090
-source "${ENV_FILE}"
-set +a
+wanted = {"POSTGRES_USER", "POSTGRES_DB", "BACKUP_DIR", "BACKUP_RETENTION_DAYS"}
+path = sys.argv[1]
+
+with open(path, encoding="utf-8") as f:
+    for raw in f:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key not in wanted:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            try:
+                value = ast.literal_eval(value)
+            except Exception:
+                value = value[1:-1]
+        print(f"{key}\t{value}")
+PY
+)
+
+POSTGRES_USER=${POSTGRES_USER:-${DOTENV_POSTGRES_USER:-}}
+POSTGRES_DB=${POSTGRES_DB:-${DOTENV_POSTGRES_DB:-}}
+BACKUP_DIR=${BACKUP_DIR:-${DOTENV_BACKUP_DIR:-/opt/backups/cpnucleo}}
+BACKUP_RETENTION_DAYS=${BACKUP_RETENTION_DAYS:-${DOTENV_BACKUP_RETENTION_DAYS:-14}}
+DEST="${BACKUP_DIR}/${TIMESTAMP}"
 
 : "${POSTGRES_USER:?POSTGRES_USER must be set in ${ENV_FILE}}"
 : "${POSTGRES_DB:?POSTGRES_DB must be set in ${ENV_FILE}}"
+
+case "${BACKUP_DIR}" in
+  ""|"/"|"."|"..")
+    echo "Refusing unsafe BACKUP_DIR='${BACKUP_DIR}'" >&2
+    exit 1
+    ;;
+  /*) ;;
+  *)
+    echo "Refusing BACKUP_DIR='${BACKUP_DIR}'; expected an absolute path." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "${BACKUP_RETENTION_DAYS}" =~ ^[0-9]+$ ]]; then
+  echo "BACKUP_RETENTION_DAYS must be a non-negative integer." >&2
+  exit 1
+fi
+
+mkdir -p "${DEST}"
+chmod 700 "${BACKUP_DIR}" "${DEST}"
 
 # Database logical dump. Custom format keeps restore flexible:
 #   docker compose -f compose.prod.yaml exec -T db pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists < dump.pgcustom
@@ -60,6 +114,7 @@ tar -czf "${DEST}/cpnucleo-config.tar.gz" \
 sha256sum "${DEST}/cpnucleo-db.pgcustom" "${DEST}/cpnucleo-config.tar.gz" \
   > "${DEST}/SHA256SUMS"
 
+# BACKUP_DIR is validated above before any deletion happens.
 find "${BACKUP_DIR}" -mindepth 1 -maxdepth 1 -type d -mtime +"${BACKUP_RETENTION_DAYS}" -exec rm -rf {} +
 
 printf 'Cpnucleo backup completed: %s\n' "${DEST}"


### PR DESCRIPTION
## Summary
- Reworks `compose.prod.yaml` for Hostinger + Traefik deployment with no public service/database ports.
- Adds public routes for web, REST API, identity API, and gRPC, while keeping NGINX as the internal REST API load balancer for parity with local development.
- Moves production service images to immutable image variables and updates `main-release.yml` to publish/deploy `sha-<github.sha>` tags.
- Adds `.env.hostinger.example` with the Hostinger production URL/env shape and `scripts/backup-hostinger.sh` for PostgreSQL + deployment config backups.
- Restores production-safe PostgreSQL durability settings by removing `fsync=0`, `full_page_writes=0`, and `synchronous_commit=0` from prod compose.

## Verification
- `docker compose --env-file .env.hostinger.example -f compose.prod.yaml config --quiet`
- Python YAML parse for `compose.prod.yaml` and `.github/workflows/main-release.yml`
- Verified `compose.prod.yaml` has no host-published ports
- `git diff --check`
- `dotnet test test/Architecture.Tests/` — 25 passed

## Notes
- Minimum VPS noted in compose: 2 vCPU / 4 GiB RAM.
- Recommended VPS noted in compose: 4 vCPU / 8 GiB RAM.
- Real VPS `.env` should be copied from `.env.hostinger.example` and filled with the actual immutable release tags/secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Hostinger VPS environment template with configuration placeholders for deployment settings
  * Enhanced Docker image tagging with per-architecture and commit SHA-based tags in CI/CD pipeline
  * Added automated backup script for deployments with database and configuration archival
  * Updated production deployment configuration with Traefik routing integration and improved database security hardening

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->