### PR TITLE
docs: refresh README and wiki source facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## About
 
-Cpnucleo is a project management and task tracking system built as a .NET 10 reference implementation for Clean Architecture, Domain-Driven Design, and a CQRS-like dual data access strategy. The REST API uses FastEndpoints with EF Core while the gRPC server uses FastEndpoints Remote Messaging with Dapper, both operating against the same PostgreSQL database. Over 25 architecture tests (NetArchTest) enforce layer dependency rules at build time, ensuring the domain layer remains free of infrastructure concerns.
+Cpnucleo is a project management and task tracking system built as a .NET 10 reference implementation for Clean Architecture, Domain-Driven Design, and a CQRS-like dual data access strategy. The REST API uses FastEndpoints with EF Core while the gRPC server uses FastEndpoints Remote Messaging with Dapper, both operating against the same PostgreSQL database. 25 architecture tests (NetArchTest) enforce layer dependency rules at build time, ensuring the domain layer remains free of infrastructure concerns.
 
 ## Tech Stack
 
@@ -35,7 +35,7 @@ Cpnucleo is a project management and task tracking system built as a .NET 10 ref
 
 ## Features
 
-- Clean Architecture with strict layer separation enforced by 25+ automated NetArchTest rules
+- Clean Architecture with strict layer separation enforced by 25 automated NetArchTest rules
 - Dual data access strategies: EF Core (REST API) and Dapper with Unit of Work (gRPC server) against the same database
 - JWT authentication via a dedicated Identity API with PBKDF2-hashed credentials
 - Rate limiting per IP: 50 req/min on WebApi, 10 req/min on IdentityApi
@@ -71,7 +71,7 @@ Cpnucleo is a project management and task tracking system built as a .NET 10 ref
 └─────────────────────────────────────────────────────┘
 ```
 
-Layer dependencies enforced by 25+ NetArchTest rules at build time.
+Layer dependencies enforced by 25 NetArchTest rules at build time.
 
 ## Getting Started
 
@@ -93,7 +93,7 @@ docker compose up
 |---------|-----|
 | WebApi (via NGINX) | http://localhost:9999 |
 | IdentityApi | http://localhost:5200 |
-| GrpcServer | http://localhost:5300 |
+| GrpcServer | http://localhost:5300 (gRPC) / http://localhost:5301 (health) |
 | WebClient | http://localhost:5400 |
 
 Development mode (build from source with Grafana LGTM observability):
@@ -138,18 +138,18 @@ dotnet test test/WebApi.Unit.Tests/            # Unit tests only
 | Suite | Framework | Coverage |
 |-------|-----------|----------|
 | Architecture.Tests | xUnit + NetArchTest | Layer deps, naming, sealed entities |
-| WebApi.Unit.Tests | NUnit + FakeItEasy + Shouldly | Endpoint happy/negative paths |
+| WebApi.Unit.Tests | NUnit + FakeItEasy + Shouldly | 49 endpoint unit-test cases; local compile cleanup currently needed |
 | WebApi.Integration.Tests | xUnit v3 + FastEndpoints.Testing | Full HTTP CRUD per entity |
 
 ## CI/CD
 
 **build-check.yml** (pull requests): builds each service, runs architecture tests, performs container health check validation.
 
-**main-release.yml** (push to main): builds and tests with `TRIM=true` and `EXTRA_OPTIMIZE=true`, builds multi-platform Docker images, pushes to GHCR, runs container health checks, deploys to Azure Web Apps.
+**main-release.yml** (push to main): builds and runs architecture tests with `TRIM=true` and `EXTRA_OPTIMIZE=true`, pushes amd64/arm64 GHCR images plus immutable `sha-${GITHUB_SHA}` manifests, runs container health checks, deploys to Azure Web Apps with OIDC.
 
 ## Documentation
 
-See the [Wiki](https://github.com/jonathanperis/cpnucleo/wiki) for detailed documentation on architecture, API reference, database setup, testing, and deployment.
+See the [Pages documentation](https://jonathanperis.github.io/cpnucleo/docs/) for detailed documentation on architecture, API reference, database setup, testing, and deployment.
 
 ## Contributing
 

--- a/docs/wiki/api-reference.md
+++ b/docs/wiki/api-reference.md
@@ -25,7 +25,7 @@ Every entity follows this consistent pattern:
 |--------|-------|-------------|
 | `POST` | `/api/{entity}` | Create a new record |
 | `GET` | `/api/{entity}/{id}` | Get a single record by ID |
-| `GET` | `/api/{entity}` | List records (paginated) |
+| `GET` | `/api/{entities}` | List records (paginated; plural route such as `/api/projects`) |
 | `PUT` | `/api/{entity}/{id}` | Update an existing record |
 | `DELETE` | `/api/{entity}/{id}` | Remove a record (soft delete) |
 
@@ -33,17 +33,17 @@ Every entity follows this consistent pattern:
 
 | Entity | Route Prefix | Tag |
 |--------|-------------|-----|
-| Appointment | `/api/appointment` | Appointments |
-| Assignment | `/api/assignment` | Assignments |
-| AssignmentImpediment | `/api/assignmentimpediment` | AssignmentImpediments |
-| AssignmentType | `/api/assignmenttype` | AssignmentTypes |
-| Impediment | `/api/impediment` | Impediments |
-| Organization | `/api/organization` | Organizations |
-| Project | `/api/project` | Projects |
-| User | `/api/user` | Users |
-| UserAssignment | `/api/userassignment` | UserAssignments |
-| UserProject | `/api/userproject` | UserProjects |
-| Workflow | `/api/workflow` | Workflows |
+| Appointment | `/api/appointment` / `/api/appointments` | Appointments |
+| Assignment | `/api/assignment` / `/api/assignments` | Assignments |
+| AssignmentImpediment | `/api/assignmentImpediment` / `/api/assignmentImpediments` | AssignmentImpediments |
+| AssignmentType | `/api/assignmentType` / `/api/assignmentTypes` | AssignmentTypes |
+| Impediment | `/api/impediment` / `/api/impediments` | Impediments |
+| Organization | `/api/organization` / `/api/organizations` | Organizations |
+| Project | `/api/project` / `/api/projects` | Projects |
+| User | `/api/user` / `/api/users` | Users |
+| UserAssignment | `/api/userAssignment` / `/api/userAssignments` | UserAssignments |
+| UserProject | `/api/userProject` / `/api/userProjects` | UserProjects |
+| Workflow | `/api/workflow` / `/api/workflows` | Workflows |
 
 ### Example: Create Appointment
 
@@ -172,8 +172,8 @@ The GrpcServer uses FastEndpoints.Messaging.Remote to handle commands over HTTP/
 
 ### Ports
 
-- Health check: `http://localhost:5300/healthz` (HTTP/1.1)
-- gRPC transport: `http://localhost:5301` (HTTP/2)
+- gRPC transport: `http://localhost:5300` (HTTP/2)
+- Health check: `http://localhost:5301/healthz` (HTTP/1.1)
 
 ### Command Pattern
 

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Cpnucleo follows Clean Architecture principles with strict layer separation enforced by automated architecture tests (NetArchTest). The system implements a CQRS-like dual strategy where the REST API and gRPC server use different data access technologies against the same PostgreSQL database.
+Cpnucleo follows Clean Architecture principles with strict layer separation enforced by 25 automated architecture tests (NetArchTest). The system implements a CQRS-like dual strategy where the REST API and gRPC server use different data access technologies against the same PostgreSQL database.
 
 ---
 
@@ -121,7 +121,7 @@ Implements data access with two strategies side by side:
 
 - FastEndpoints.Messaging.Remote for gRPC-style command/handler pattern
 - Uses Dapper via `IUnitOfWork` for data access
-- HTTP/2 on port 5021 for gRPC transport
+- HTTP/2 on port 5020 for gRPC transport, with HTTP/1 health checks on port 5021
 - Command/Result pattern via `GrpcServer.Contracts`
 - All 11 entities have 5 handlers each: Create, GetById, List, Remove, Update (55 handlers total)
 
@@ -151,7 +151,7 @@ The system demonstrates two parallel approaches to the same domain:
 | Framework | FastEndpoints | FastEndpoints.Messaging.Remote |
 | Data Access | EF Core + ApplicationDbContext | Dapper + UnitOfWork |
 | Transport | HTTP/1.1 REST | HTTP/2 gRPC |
-| Internal Port | 5000 | 5021 |
+| Internal Port | 5000 | 5020 (HTTP/2 gRPC) + 5021 (HTTP/1 health) |
 | Load Balanced | Yes (NGINX, 2 instances) | No |
 
 Both implementations share the same Domain entities and PostgreSQL database.

--- a/docs/wiki/deployment.md
+++ b/docs/wiki/deployment.md
@@ -49,7 +49,7 @@ Differences from base:
 - Resource reservations: 0.25 CPU / 256MB per API, 0.50 CPU / 512MB per DB
 - Resource limits: 0.50 CPU / 512MB per API, 1.0 CPU / 1GB for DB
 - JSON logging with rotation: 10MB max size, 3 files retained
-- No build step (uses pre-built images)
+- No build step; production image variables such as `CPNUCLEO_WEB_API_IMAGE` are required and should point at immutable GHCR tags (for example `sha-...`)
 
 ---
 
@@ -77,7 +77,7 @@ Each service has a multi-stage Dockerfile supporting configurable build options:
 
 ### Platform Support
 
-All images are built for `linux/amd64` and `linux/arm64/v8`.
+The release workflow builds `linux/amd64` and `linux/arm64/v8` images, then merges them into `latest` and immutable `sha-${GITHUB_SHA}` manifests.
 
 ---
 
@@ -144,19 +144,18 @@ Triggered on push to main and manual dispatch.
 
 1. **Setup, Build & Test** -- Same as build check but with `TRIM=true`, `EXTRA_OPTIMIZE=true`, `BUILD_CONFIGURATION=Release`
 
-2. **Build & Push Docker Image** (depends on test)
-   - Setup QEMU and Docker Buildx for multi-platform builds
-   - Login to GHCR
-   - Build and push images for `linux/amd64` and `linux/arm64/v8`
-   - Images pushed to GHCR: `ghcr.io/jonathanperis/cpnucleo-{service}:latest`
+2. **Build & Push Docker Images** (depends on test)
+   - Build `linux/amd64` images tagged `sha-${GITHUB_SHA}-amd64` and `latest`
+   - Build `linux/arm64/v8` images tagged `sha-${GITHUB_SHA}-arm64` and `latest-arm64`
+   - Merge both architectures into multi-arch `sha-${GITHUB_SHA}` and `latest` manifests for each GHCR image
 
 3. **Container Healthcheck Test** (depends on push)
    - Pull production images
    - Run healthcheck validation
 
-4. **Deploy to Azure** (depends on healthcheck)
+4. **Deploy to Azure** (depends on infrastructure + manifest merge)
    - Deploy each service to its Azure Web App
-   - Uses publish profiles stored in GitHub Secrets
+   - Uses Azure OIDC secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`) and immutable `sha-${GITHUB_SHA}` image tags
 
 ### Azure Deployment Targets
 
@@ -188,10 +187,9 @@ Triggered on push to main and manual dispatch.
 |--------|---------|
 | `GITHUB_TOKEN` | GHCR authentication (automatic) |
 | `DB_CONNECTION_STRING` | Production database connection |
-| `AZURE_WEBAPP_PUBLISH_PROFILE_WEBAPI` | Azure publish profile for WebApi |
-| `AZURE_WEBAPP_PUBLISH_PROFILE_GRPCSERVER` | Azure publish profile for GrpcServer |
-| `AZURE_WEBAPP_PUBLISH_PROFILE_IDENTITYAPI` | Azure publish profile for IdentityApi |
-| `AZURE_WEBAPP_PUBLISH_PROFILE_WEBCLIENT` | Azure publish profile for WebClient |
+| `AZURE_CLIENT_ID` | Azure OIDC client ID |
+| `AZURE_TENANT_ID` | Azure tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
 
 ---
 

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -40,7 +40,7 @@ docker compose -f compose.yaml -f compose.override.yaml up --build
 
 ### Production Mode
 
-Uses pre-built images with resource reservations, restart policies, and structured JSON logging:
+Uses image variables, Traefik labels, resource reservations, restart policies, and structured JSON logging for production hosts:
 
 ```bash
 docker compose -f compose.yaml -f compose.prod.yaml up -d
@@ -55,7 +55,7 @@ Once running, the services are available at:
 | WebApi (instance 1) | http://localhost:5100 | REST API |
 | WebApi (instance 2) | http://localhost:5111 | REST API (load-balanced pair) |
 | IdentityApi | http://localhost:5200 | JWT Authentication API |
-| GrpcServer | http://localhost:5300 (health) / :5301 (gRPC) | gRPC command server |
+| GrpcServer | http://localhost:5300 (gRPC) / http://localhost:5301 (health) | gRPC command server |
 | WebClient | http://localhost:5400 | Blazor UI |
 | NGINX | http://localhost:9999 | Reverse proxy (load balances WebApi) |
 | PostgreSQL | localhost:5432 | Database |
@@ -69,7 +69,7 @@ All services expose a health endpoint:
 ```bash
 curl http://localhost:5100/healthz   # WebApi
 curl http://localhost:5200/healthz   # IdentityApi
-curl http://localhost:5300/healthz   # GrpcServer
+curl http://localhost:5301/healthz   # GrpcServer (HTTP/1 health port)
 curl http://localhost:5400/healthz   # WebClient
 ```
 

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -9,9 +9,9 @@ Cpnucleo is a project management and task tracking system built with .NET 10, de
 | Page | Description |
 |------|-------------|
 | [Architecture](architecture) | Clean Architecture layers, CQRS dual implementation, DDD patterns |
-| [Getting Started](getting_started) | Prerequisites, build, run with Docker Compose or locally |
-| [Project Structure](project_structure) | Full tree of `src/` and `test/` with descriptions |
-| [API Reference](api_reference) | WebApi endpoints, IdentityApi auth, GrpcServer contracts |
+| [Getting Started](getting-started) | Prerequisites, build, run with Docker Compose or locally |
+| [Project Structure](project-structure) | Full tree of `src/` and `test/` with descriptions |
+| [API Reference](api-reference) | WebApi endpoints, IdentityApi auth, GrpcServer contracts |
 | [Database](database) | PostgreSQL setup, EF Core, Dapper, init scripts |
 | [Testing](testing) | Architecture tests, unit tests, integration tests |
 | [Deployment](deployment) | Docker Compose configs, GitHub Actions CI/CD, NGINX |
@@ -21,7 +21,7 @@ Cpnucleo is a project management and task tracking system built with .NET 10, de
 
 ## Key Features
 
-- Clean Architecture with strict layer dependency enforcement validated by 25+ architecture tests
+- Clean Architecture with strict layer dependency enforcement validated by 25 architecture tests
 - Dual data access: EF Core for the REST API, Dapper with Unit of Work for the gRPC server
 - FastEndpoints for both REST endpoints and gRPC-style remote command handling
 - JWT authentication via the dedicated Identity API with PBKDF2-hashed credentials

--- a/docs/wiki/project-structure.md
+++ b/docs/wiki/project-structure.md
@@ -69,7 +69,7 @@ Infrastructure/
 │   │   ├── ApplicationDbContext.cs       # EF Core DbContext implementation
 │   │   └── IApplicationDbContext.cs      # DbContext interface
 │   ├── Helpers/
-│   │   └── FakeDataHelper.cs             # Bogus-based test data generator
+│   │   └── FakeData.cs                   # Bogus-based test data generator
 │   └── Mappings/
 │       └── ...                           # EF Core entity configurations
 ├── Migrations/
@@ -132,7 +132,7 @@ gRPC command server using FastEndpoints Remote Messaging with Dapper data access
 ```
 GrpcServer/
 ├── GrpcServer.csproj                     # FastEndpoints.Messaging.Remote, Mapperly, OpenTelemetry
-├── Program.cs                            # HTTP/2 on port 5021, handler registration (55 handlers)
+├── Program.cs                            # HTTP/2 on port 5020, HTTP/1 health on 5021, handler registration (55 handlers)
 ├── Usings.cs
 ├── Dockerfile
 ├── Common/
@@ -244,7 +244,7 @@ Validates Clean Architecture dependency rules using NetArchTest.
 ```
 Architecture.Tests/
 ├── Architecture.Tests.csproj             # xUnit, NetArchTest.Rules, FluentAssertions
-├── ArchitectureTests.cs                  # 25+ architecture validation tests
+├── ArchitectureTests.cs                  # 25 architecture validation tests
 ├── Usings.cs
 └── README.md
 ```
@@ -264,7 +264,7 @@ WebApi.Unit.Tests/
 
 ### WebApi.Integration.Tests (`test/WebApi.Integration.Tests/`)
 
-Integration tests running against real services.
+Integration tests using FastEndpoints.Testing host fixtures; run manually when a database-backed integration pass is needed.
 
 ```
 WebApi.Integration.Tests/

--- a/docs/wiki/technologies.md
+++ b/docs/wiki/technologies.md
@@ -25,13 +25,13 @@
 
 | Technology | Version | Purpose |
 |-----------|---------|---------|
-| Entity Framework Core | 10.0.3 | ORM for WebApi and IdentityApi |
-| EF Core Design | 10.0.3 | Migration tooling |
+| Entity Framework Core | 10.0.7 | ORM for WebApi and IdentityApi |
+| EF Core Design | 10.0.7 | Migration tooling |
 | Npgsql | 10.0.1 | PostgreSQL .NET driver |
 | Npgsql.EntityFrameworkCore.PostgreSQL | 10.0.0 | EF Core PostgreSQL provider |
 | Dapper | 2.1.72 | Micro-ORM for GrpcServer |
 | Dapper.AOT | 1.0.48 | Compile-time SQL interception |
-| Delta | 9.0.0 | HTTP conditional requests via DB timestamps |
+| Delta | 9.0.1 | HTTP conditional requests via DB timestamps |
 
 ## Database
 
@@ -43,7 +43,7 @@
 
 | Technology | Version | Purpose |
 |-----------|---------|---------|
-| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.3 | JWT Bearer authentication middleware |
+| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.7 | JWT Bearer authentication middleware |
 
 ## Mapping
 
@@ -61,13 +61,13 @@
 
 | Technology | Version | Purpose |
 |-----------|---------|---------|
-| OpenTelemetry.Exporter.Console | 1.15.1 | Console telemetry export |
-| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.0 | OTLP telemetry export |
-| OpenTelemetry.Extensions.Hosting | 1.15.0 | Host integration |
-| OpenTelemetry.Instrumentation.AspNetCore | 1.15.0 | ASP.NET Core instrumentation |
-| OpenTelemetry.Instrumentation.Http | 1.15.0 | HTTP client instrumentation |
+| OpenTelemetry.Exporter.Console | 1.15.3 | Console telemetry export |
+| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.3 | OTLP telemetry export |
+| OpenTelemetry.Extensions.Hosting | 1.15.3 | Host integration |
+| OpenTelemetry.Instrumentation.AspNetCore | 1.15.2 | ASP.NET Core instrumentation |
+| OpenTelemetry.Instrumentation.Http | 1.15.1 | HTTP client instrumentation |
 | OpenTelemetry.Instrumentation.Process | 1.12.0-beta.1 | Process metrics |
-| OpenTelemetry.Instrumentation.Runtime | 1.15.0 | .NET runtime metrics |
+| OpenTelemetry.Instrumentation.Runtime | 1.15.1 | .NET runtime metrics |
 | Grafana LGTM | Latest | Observability stack (dev only, via Docker) |
 
 ## Frontend
@@ -91,8 +91,8 @@
 | FakeItEasy | 9.0.1 | Mocking framework |
 | Shouldly | 4.3.0 | Assertion library |
 | Bogus | 35.6.5 | Fake data generation |
-| coverlet.collector | 8.0.1 | Code coverage collection |
-| Microsoft.NET.Test.Sdk | 18.0.1 | .NET test infrastructure |
+| coverlet.collector | 10.0.0 | Code coverage collection |
+| Microsoft.NET.Test.Sdk | 18.5.1 | .NET test infrastructure |
 
 ## Infrastructure & DevOps
 

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Cpnucleo has three test projects covering architecture validation, unit testing, and integration testing.
+Cpnucleo has three test projects covering 25 architecture rules, 49 WebApi unit-test cases in source, and 55 integration tests. The active GitHub Actions gates run architecture tests and container health checks; unit/integration suites are kept for local/manual validation.
 
 ---
 
@@ -10,7 +10,7 @@ Cpnucleo has three test projects covering architecture validation, unit testing,
 |---------|-----------|-------|--------------|
 | Architecture.Tests | xUnit | Clean Architecture rules | NetArchTest.Rules, FluentAssertions |
 | WebApi.Unit.Tests | NUnit | Endpoint unit tests | FakeItEasy, Shouldly, FastEndpoints |
-| WebApi.Integration.Tests | xUnit v3 | End-to-end endpoint tests | FastEndpoints.Testing, Shouldly |
+| WebApi.Integration.Tests | xUnit v3 | 55 endpoint integration tests | FastEndpoints.Testing, Shouldly |
 
 ---
 
@@ -71,7 +71,7 @@ These tests enforce Clean Architecture dependency rules at build time using NetA
 
 ## Unit Tests (`test/WebApi.Unit.Tests/`)
 
-Unit tests for WebApi endpoints using NUnit with FakeItEasy for mocking and Shouldly for assertions.
+Unit tests for WebApi endpoints using NUnit with FakeItEasy for mocking and Shouldly for assertions. The source contains 49 test cases, but the suite is not part of the active CI gate and currently needs cleanup around several `Remove*` request-model references before it compiles end to end.
 
 ### Structure
 
@@ -97,7 +97,7 @@ WebApi.Unit.Tests/
 
 ## Integration Tests (`test/WebApi.Integration.Tests/`)
 
-Integration tests that exercise the full request pipeline using FastEndpoints.Testing and xUnit v3.
+55 integration tests exercise the FastEndpoints request pipeline with xUnit v3 and shared host fixtures.
 
 ### Structure
 
@@ -123,14 +123,14 @@ WebApi.Integration.Tests/
 
 ### Prerequisites
 
-Integration tests require a running PostgreSQL database. In CI, this is provisioned via Docker Compose:
+Integration tests require a database-backed test environment. For manual runs, start PostgreSQL with Docker Compose first:
 
 ```bash
 docker compose up db -d --build --force-recreate
 sleep 30
 ```
 
-> Integration tests are currently commented out in CI workflows and are run manually.
+> Integration tests are present in source but are not part of the active GitHub Actions gates; PR and release workflows currently run architecture tests and container health checks.
 
 ---
 
@@ -180,4 +180,4 @@ Architecture tests run automatically in both CI workflows:
 - **build-check.yml** (PR): runs architecture tests for each service (WebApi, GrpcServer, IdentityApi, WebClient)
 - **main-release.yml** (push to main): runs architecture tests before building Docker images
 
-Unit and integration tests are configured in the workflows but currently commented out, pending further setup.
+Unit and integration test projects remain available for local/manual runs; the active GitHub Actions gates run architecture tests and container health checks. Latest local audit: `Architecture.Tests` passes 25/25, while `WebApi.Unit.Tests` has compile drift around removed `Remove*.Request` model types.

--- a/scripts/check-docs-drift.py
+++ b/scripts/check-docs-drift.py
@@ -28,6 +28,14 @@ def assert_absent(path: str, needle: str) -> None:
         fail(f"{path} still contains stale text: {needle!r}")
 
 
+def require_text(source_name: str, text: str, needle: str, *, present: bool = True) -> None:
+    found = needle in text
+    if present and not found:
+        fail(f"{source_name} is missing expected text: {needle!r}")
+    if not present and found:
+        fail(f"{source_name} still contains stale text: {needle!r}")
+
+
 def count_attrs(path: str, pattern: str) -> int:
     total = 0
     for file in (ROOT / path).rglob("*.cs"):
@@ -37,34 +45,37 @@ def count_attrs(path: str, pattern: str) -> int:
 
 def main() -> None:
     global_json = read("global.json")
-    assert '"version": "10.0.102"' in global_json
+    require_text("global_json", global_json, '"version": "10.0.102"')
 
     compose = read("compose.yaml")
-    assert 'image: postgres:16.7' in compose
-    assert '"5300:5020"' in compose
-    assert '"5301:5021"' in compose
-    assert 'image: ghcr.io/jonathanperis/cpnucleo-web-api:latest' in compose
+    require_text("compose", compose, "image: postgres:16.7")
+    require_text("compose", compose, '"5300:5020"')
+    require_text("compose", compose, '"5301:5021"')
+    require_text("compose", compose, "image: ghcr.io/jonathanperis/cpnucleo-web-api:latest")
 
     grpc_program = read("src/GrpcServer/Program.cs")
-    assert "ListenAnyIP(5020" in grpc_program and "HttpProtocols.Http2" in grpc_program
-    assert "ListenAnyIP(5021" in grpc_program and "HttpProtocols.Http1" in grpc_program
+    require_text("grpc_program", grpc_program, "ListenAnyIP(5020")
+    require_text("grpc_program", grpc_program, "HttpProtocols.Http2")
+    require_text("grpc_program", grpc_program, "ListenAnyIP(5021")
+    require_text("grpc_program", grpc_program, "HttpProtocols.Http1")
 
     main_release = read(".github/workflows/main-release.yml")
-    assert "${{ matrix.image }}:sha-${{ github.sha }}-amd64" in main_release
-    assert "${{ matrix.image }}:sha-${{ github.sha }}-arm64" in main_release
-    assert "--tag ${{ matrix.image }}:sha-${{ github.sha }}" in main_release
-    assert "images: ${{ matrix.image }}" in main_release
-    assert "AZURE_CLIENT_ID" in main_release
-    assert "AZURE_WEBAPP_PUBLISH_PROFILE" not in main_release
+    require_text("main_release", main_release, "${{ matrix.image }}:sha-${{ github.sha }}-amd64")
+    require_text("main_release", main_release, "${{ matrix.image }}:sha-${{ github.sha }}-arm64")
+    require_text("main_release", main_release, "--tag ${{ matrix.image }}:sha-${{ github.sha }}")
+    require_text("main_release", main_release, "images: ${{ matrix.image }}")
+    require_text("main_release", main_release, "AZURE_CLIENT_ID")
+    require_text("main_release", main_release, "AZURE_WEBAPP_PUBLISH_PROFILE", present=False)
 
     deploy = read(".github/workflows/deploy.yml")
-    assert "pages-docs-deploy.yml@main" in deploy
+    require_text("deploy", deploy, "pages-docs-deploy.yml@main")
 
     wiki_files = sorted((ROOT / "docs/wiki").glob("*.md"))
     slugs = {p.stem for p in wiki_files}
     sidebar = read("docs/src/lib/sidebar.config.ts")
+    sidebar_slugs = set(re.findall(r'"([a-z0-9-]+)"', sidebar))
     for slug in slugs:
-        if slug not in sidebar:
+        if slug not in sidebar_slugs:
             fail(f"docs/wiki/{slug}.md is not represented in sidebar config")
 
     arch_tests = count_attrs("test/Architecture.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")

--- a/scripts/check-docs-drift.py
+++ b/scripts/check-docs-drift.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Source-backed documentation drift checks for README and wiki facts."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def fail(message: str) -> None:
+    print(f"docs drift: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def assert_contains(path: str, needle: str) -> None:
+    if needle not in read(path):
+        fail(f"{path} is missing expected text: {needle!r}")
+
+
+def assert_absent(path: str, needle: str) -> None:
+    if needle in read(path):
+        fail(f"{path} still contains stale text: {needle!r}")
+
+
+def count_attrs(path: str, pattern: str) -> int:
+    total = 0
+    for file in (ROOT / path).rglob("*.cs"):
+        total += len(re.findall(pattern, file.read_text(encoding="utf-8")))
+    return total
+
+
+def main() -> None:
+    global_json = read("global.json")
+    assert '"version": "10.0.102"' in global_json
+
+    compose = read("compose.yaml")
+    assert 'image: postgres:16.7' in compose
+    assert '"5300:5020"' in compose
+    assert '"5301:5021"' in compose
+    assert 'image: ghcr.io/jonathanperis/cpnucleo-web-api:latest' in compose
+
+    grpc_program = read("src/GrpcServer/Program.cs")
+    assert "ListenAnyIP(5020" in grpc_program and "HttpProtocols.Http2" in grpc_program
+    assert "ListenAnyIP(5021" in grpc_program and "HttpProtocols.Http1" in grpc_program
+
+    main_release = read(".github/workflows/main-release.yml")
+    assert "${{ matrix.image }}:sha-${{ github.sha }}-amd64" in main_release
+    assert "${{ matrix.image }}:sha-${{ github.sha }}-arm64" in main_release
+    assert "--tag ${{ matrix.image }}:sha-${{ github.sha }}" in main_release
+    assert "images: ${{ matrix.image }}" in main_release
+    assert "AZURE_CLIENT_ID" in main_release
+    assert "AZURE_WEBAPP_PUBLISH_PROFILE" not in main_release
+
+    deploy = read(".github/workflows/deploy.yml")
+    assert "pages-docs-deploy.yml@main" in deploy
+
+    wiki_files = sorted((ROOT / "docs/wiki").glob("*.md"))
+    slugs = {p.stem for p in wiki_files}
+    sidebar = read("docs/src/lib/sidebar.config.ts")
+    for slug in slugs:
+        if slug not in sidebar:
+            fail(f"docs/wiki/{slug}.md is not represented in sidebar config")
+
+    arch_tests = count_attrs("test/Architecture.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
+    unit_tests = count_attrs("test/WebApi.Unit.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
+    integration_tests = count_attrs("test/WebApi.Integration.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
+    if (arch_tests, unit_tests, integration_tests) != (25, 49, 55):
+        fail(f"unexpected test counts: architecture={arch_tests}, unit={unit_tests}, integration={integration_tests}")
+
+    endpoint_count = len(list((ROOT / "src/WebApi/Endpoints").glob("**/Endpoint.cs")))
+    handler_count = len(list((ROOT / "src/GrpcServer/Handlers").glob("**/*Handler.cs")))
+    command_count = len(list((ROOT / "src/GrpcServer.Contracts/Commands").glob("**/*Command.cs")))
+    if (endpoint_count, handler_count, command_count) != (55, 55, 55):
+        fail(f"unexpected endpoint/handler/command counts: {endpoint_count}/{handler_count}/{command_count}")
+
+    assert_contains("README.md", "25 architecture tests")
+    assert_contains("README.md", "Pages documentation")
+    assert_absent("README.md", "github.com/jonathanperis/cpnucleo/wiki")
+    assert_absent("docs/wiki/getting-started.md", "http://localhost:5300/healthz")
+    assert_contains("docs/wiki/getting-started.md", "http://localhost:5301/healthz")
+    assert_contains("docs/wiki/api-reference.md", "gRPC transport: `http://localhost:5300` (HTTP/2)")
+    assert_contains("docs/wiki/api-reference.md", "Health check: `http://localhost:5301/healthz` (HTTP/1.1)")
+    assert_contains("docs/wiki/testing.md", "55 integration tests")
+    assert_contains("docs/wiki/deployment.md", "OIDC")
+
+    print("README/wiki drift checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/WebApi.Unit.Tests/README.md
+++ b/test/WebApi.Unit.Tests/README.md
@@ -46,12 +46,12 @@ A.CallTo(() => fakeDbContext.Entities).Returns(fakeDbSet);
 
 - **Total Test Files**: 11
 - **Total Tests Written**: 49
-- **Currently Passing**: 47 ✅
-- **Currently Skipped**: 2 (EF Core Create operations with DbSet.Any() extension method)
+- **Current local status**: compile cleanup needed around several `Remove*.Request` model references before the suite can run end to end
+- **Known skipped cases in source**: 2 EF Core Create operations with `DbSet.Any()` extension-method mocking limitations
 
 ## Dependencies
 
-- FastEndpoints 7.2.0
+- FastEndpoints 8.1.0
 - FakeItEasy 9.0.1
 - Shouldly 4.3.0
 - NUnit 4.4.0
@@ -66,5 +66,5 @@ dotnet test test/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj
 
 - Two Create tests for User and Workflow endpoints are skipped because DbSet.Any() is a LINQ extension method that cannot be mocked with FakeItEasy
 - These scenarios are better tested with integration tests that use an in-memory database
-- All repository-based endpoints are fully tested and passing
-- EF Core-based endpoints have comprehensive Read/Update/Delete coverage
+- Repository-based endpoint coverage exists, but latest source drift means the suite should be repaired before treating it as a passing gate
+- EF Core-based endpoints have Read/Update/Delete coverage in source, with the same caveat that the suite currently needs compile cleanup


### PR DESCRIPTION
## Summary
- refresh README and wiki claims against current source/workflows
- correct gRPC port mapping, API route casing/plural list routes, Pages docs links, deployment/OIDC/image tag details, and package versions
- add `scripts/check-docs-drift.py` to assert high-value README/wiki facts against source files, workflows, routes, and test counts
- document the current WebApi unit-test compile drift discovered during the audit instead of claiming it is a passing gate

## Test Plan
- [x] `python3 scripts/check-docs-drift.py`
- [x] `git diff --check`
- [x] `dotnet test test/Architecture.Tests/Architecture.Tests.csproj --no-restore`
- [x] `cd docs && NODE_ENV=production bun run build`
- [x] generated HTML link/marker smoke check for docs routes
- [x] attempted `dotnet test test/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj --no-restore` (fails on pre-existing/source-drift `Remove*.Request` references; now documented)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated service configuration documentation with accurate endpoint details
  * Clarified Clean Architecture validation enforces 25 checks at build time
  * Enhanced API reference with consistent CRUD route patterns

* **Chores**
  * Updated technology stack versions including .NET and OpenTelemetry packages
  * Added automated documentation consistency validation

* **Tests**
  * Refined test documentation with concrete test counts and CI/CD integration details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->