### PR TITLE
chore: align dev compose observability stack

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,13 @@ POSTGRES_DB=cpnucleo
 # and multiplexing, which are important for performance in a microservices architecture
 DB_CONNECTION_STRING=Host=db;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Database=${POSTGRES_DB};Minimum Pool Size=10;Maximum Pool Size=10;Multiplexing=true
 
+# Runtime configuration
+ASPNETCORE_ENVIRONMENT=Development
+
 # OpenTelemetry configuration
-# Note: The OpenTelemetry Collector must be running and accessible at the specified endpoint
-# This example uses the default endpoint for the OpenTelemetry Collector
+# Local Docker Compose uses the same telemetry path as production:
+# app containers -> otel-collector -> otel-lgtm.
+# If you run an app directly on the host instead of in Docker, override this as:
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 OTEL_METRIC_EXPORT_INTERVAL=5000

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,60 +1,65 @@
 name: "cpnucleo-dev"
 
-# Consolidated common healthcheck configurations.
-x-common-healthcheck:
-  x-healthcheck-api: &healthcheck-api
-    test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
-    interval: 30s
-    timeout: 10s
-    retries: 3
-  x-healthcheck-identity: &healthcheck-identity
-    test: ["CMD", "curl", "-f", "http://localhost:5010/healthz"]
-    interval: 30s
-    timeout: 10s
-    retries: 3
-  x-healthcheck-grpcserver: &healthcheck-grpcserver
-    test: ["CMD", "curl", "-f", "http://localhost:5021/healthz"]
-    interval: 30s
-    timeout: 10s
-    retries: 3
-  x-healthcheck-webclient: &healthcheck-webclient
-    test: ["CMD", "curl", "-f", "http://localhost:5030/healthz"]
-    interval: 30s
-    timeout: 10s
-    retries: 3
+# Development profile. It preserves the production observability flow
+# (application containers -> otel-collector -> LGTM), but publishes Grafana and
+# OTLP ports on localhost so local tools can inspect or send telemetry directly.
 
-# Extension defining common API configuration for development builds.
 x-common-api-dev: &common-api-dev
+  depends_on:
+    db:
+      condition: service_healthy
+    otel-collector:
+      condition: service_started
   env_file:
-    - .env    
+    - .env
   deploy:
     resources:
       limits:
         cpus: "0.4"
         memory: "100MB"
-        
+
 services:
-  webapi1-cpnucleo: &webapi1
+  otel-lgtm:
+    ports:
+      # Grafana UI for local development: http://localhost:3000
+      - "3000:3000"
+
+  otel-collector:
+    ports:
+      # Optional local OTLP endpoints for host tools and SDKs during development.
+      - "4317:4317"
+      - "4318:4318"
+
+  webapi1-cpnucleo:
     <<: *common-api-dev
     build:
       context: ./src/
       dockerfile: ./WebApi/Dockerfile
       args:
-        CACHE: "true"      
+        CACHE: "true"
         AOT: false
         TRIM: false
         EXTRA_OPTIMIZE: false
         BUILD_CONFIGURATION: Debug
         ASPNETCORE_ENVIRONMENT: Development
     ports:
-      # Development mapping: host port 5010 => container port 5000
+      # Development mapping: host port 5100 => container port 5000.
       - "5100:5000"
-    healthcheck: *healthcheck-api
 
   webapi2-cpnucleo:
-    <<: [*webapi1, *common-api-dev]
+    <<: *common-api-dev
+    build:
+      context: ./src/
+      dockerfile: ./WebApi/Dockerfile
+      args:
+        CACHE: "true"
+        AOT: false
+        TRIM: false
+        EXTRA_OPTIMIZE: false
+        BUILD_CONFIGURATION: Debug
+        ASPNETCORE_ENVIRONMENT: Development
     ports:
-      # Development mapping: host port 5111 => container port 5000
+      # Development mapping: host port 5111 => container port 5000.
       - "5111:5000"
 
   identityapi-cpnucleo:
@@ -70,9 +75,8 @@ services:
         BUILD_CONFIGURATION: Debug
         ASPNETCORE_ENVIRONMENT: Development
     ports:
-      # Development mapping: host port 5200 => container port 5010
+      # Development mapping: host port 5200 => container port 5010.
       - "5200:5010"
-    healthcheck: *healthcheck-identity
 
   grpcserver-cpnucleo:
     <<: *common-api-dev
@@ -87,13 +91,13 @@ services:
         BUILD_CONFIGURATION: Debug
         ASPNETCORE_ENVIRONMENT: Development
     ports:
-      # Development mapping: host port 5300 => container port 5020
+      # Development mapping: host port 5300 => container port 5020.
       - "5300:5020"
-      # Development mapping: host port 5301 => container port 5021
+      # Development mapping: host port 5301 => container port 5021.
       - "5301:5021"
-    healthcheck: *healthcheck-grpcserver
 
   webclient-cpnucleo:
+    <<: *common-api-dev
     build:
       context: ./src/
       dockerfile: ./WebClient/Dockerfile
@@ -105,41 +109,5 @@ services:
         BUILD_CONFIGURATION: Debug
         ASPNETCORE_ENVIRONMENT: Development
     ports:
-      # Development mapping: host port 5400 => container port 5030
+      # Development mapping: host port 5400 => container port 5030.
       - "5400:5030"
-    healthcheck: *healthcheck-webclient
-    env_file:
-      - .env    
-    deploy:
-      resources:
-        limits:
-          cpus: "0.4"
-          memory: "100MB"
-          
-  otel-lgtm:
-    image: grafana/otel-lgtm
-    volumes:
-      - otel_lgtm_data:/data
-    ports:
-      # Exposing ports for OpenTelemetry collector in development
-      - "3000:3000"
-      - "4317:4317"
-      - "4318:4318"
-    # healthcheck:
-    #   test: ["CMD", "curl", "-f", "http://localhost:3000"]
-    #   interval: 30s
-    #   timeout: 10s
-    #   retries: 3
-
-volumes:
-  otel_lgtm_data:
-    driver: local
-    labels:
-      - "com.example.service=otel-lgtm"
-
-networks:
-  default:
-    name: cpnucleo_network
-    driver: bridge
-    driver_opts:
-      com.example.description: "Default network for cpnucleo services"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,9 @@
 name: "cpnucleo-default"
 
-# Consolidated common healthcheck configurations.
+# Default/local profile. Keeps the same observability topology as production
+# (apps -> otel-collector -> LGTM) while compose.override.yaml decides which
+# ports are convenient to publish during development.
+
 x-common-healthcheck:
   x-healthcheck-api: &healthcheck-api
     test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
@@ -23,11 +26,12 @@ x-common-healthcheck:
     timeout: 10s
     retries: 3
 
-# Extension defining common configuration for API services in the default configuration.
 x-common-api: &common-api
   depends_on:
     db:
       condition: service_healthy
+    otel-collector:
+      condition: service_started
   env_file:
     - .env
   deploy:
@@ -36,59 +40,91 @@ x-common-api: &common-api
         cpus: "0.4"
         memory: "100MB"
 
+x-common-logging: &common-logging
+  logging:
+    driver: "json-file"
+    options:
+      max-size: "10m"
+      max-file: "3"
+
 services:
+  otel-lgtm:
+    image: grafana/otel-lgtm:0.11.10
+    container_name: otel-lgtm-cpnucleo
+    volumes:
+      - otel_lgtm_data:/data
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    expose:
+      - "3000"
+      - "4317"
+      - "4318"
+    <<: *common-logging
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.126.0
+    container_name: otel-collector-cpnucleo
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otelcol-contrib/config.yaml:ro
+    depends_on:
+      - otel-lgtm
+    expose:
+      - "4317"
+      - "4318"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: "256M"
+    <<: *common-logging
+
   webapi1-cpnucleo: &webapi1
-    <<: *common-api
+    <<: [*common-api, *common-logging]
     image: ghcr.io/jonathanperis/cpnucleo-web-api:latest
     container_name: webapi1-cpnucleo
     ports:
-      # Mapping internal port 5000 to external host port 5100 for webapi1 service
+      # Mapping internal port 5000 to external host port 5100 for webapi1 service.
       - "5100:5000"
     healthcheck: *healthcheck-api
 
   webapi2-cpnucleo:
-    <<: [*webapi1, *common-api]
+    <<: [*webapi1, *common-api, *common-logging]
     container_name: webapi2-cpnucleo
     ports:
-      # Mapping internal port 5000 to external host port 5111 for webapi2 service
+      # Mapping internal port 5000 to external host port 5111 for webapi2 service.
       - "5111:5000"
 
   identityapi-cpnucleo:
-    <<: *common-api
+    <<: [*common-api, *common-logging]
     image: ghcr.io/jonathanperis/cpnucleo-identity-api:latest
     container_name: identityapi-cpnucleo
     ports:
-      # Mapping internal port 5010 to external host port 5200 for identity API service
+      # Mapping internal port 5010 to external host port 5200 for identity API service.
       - "5200:5010"
     healthcheck: *healthcheck-identity
 
   grpcserver-cpnucleo:
-    <<: *common-api
+    <<: [*common-api, *common-logging]
     image: ghcr.io/jonathanperis/cpnucleo-grpc-server:latest
     container_name: grpcserver-cpnucleo
     ports:
-      # Mapping internal port 5020 to external host port 5300 for grpc server service
+      # Mapping internal port 5020 to external host port 5300 for gRPC server service.
       - "5300:5020"
-      # Mapping internal port 5021 to external host port 5301 for grpc server service
+      # Mapping internal port 5021 to external host port 5301 for gRPC server health checks.
       - "5301:5021"
     healthcheck: *healthcheck-grpcserver
 
   webclient-cpnucleo:
-    <<: *common-api
+    <<: [*common-api, *common-logging]
     image: ghcr.io/jonathanperis/cpnucleo-web-client:latest
     container_name: webclient-cpnucleo
     ports:
-      # Mapping internal port 5030 to external host port 5400 for web client service
+      # Mapping internal port 5030 to external host port 5400 for web client service.
       - "5400:5030"
     healthcheck: *healthcheck-webclient
-    env_file:
-      - .env      
-    deploy:
-      resources:
-        limits:
-          cpus: "0.4"
-          memory: "100MB"
-          
+
   db:
     image: postgres:16.7
     container_name: db-cpnucleo
@@ -100,38 +136,44 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
-      retries: 5      
+      retries: 5
     ports:
-      # Exposing default PostgreSQL port on both host and container
+      # Exposing default PostgreSQL port in the local/default profile.
       - "5432:5432"
     deploy:
       resources:
         limits:
           cpus: "0.5"
-          memory: "330MB"      
+          memory: "330MB"
     command: postgres -c checkpoint_timeout=600 -c max_wal_size=4096 -c synchronous_commit=0 -c fsync=0 -c full_page_writes=0
+    <<: *common-logging
 
   nginx:
-    image: nginx
+    image: nginx:1.27-alpine
     container_name: nginx-cpnucleo
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-    depends_on: 
+    depends_on:
       - webapi1-cpnucleo
       - webapi2-cpnucleo
     ports:
-      # Mapping external port 9999 to internal port 9999 for NGINX reverse-proxy
+      # Mapping external port 9999 to internal port 9999 for NGINX reverse proxy.
       - "9999:9999"
     deploy:
       resources:
         limits:
           cpus: "0.2"
           memory: "20MB"
+    <<: *common-logging
 
 volumes:
+  otel_lgtm_data:
+    driver: local
+    labels:
+      - "com.example.service=cpnucleo-otel-lgtm"
   db_data:
     driver: local
     labels:

--- a/compose.yaml
+++ b/compose.yaml
@@ -148,7 +148,10 @@ services:
         limits:
           cpus: "0.5"
           memory: "330MB"
-    command: postgres -c checkpoint_timeout=600 -c max_wal_size=4096 -c synchronous_commit=0 -c fsync=0 -c full_page_writes=0
+    # Keep local/default storage durable by default. Data-unsafe PostgreSQL flags
+    # such as fsync=off, synchronous_commit=off, or full_page_writes=off should
+    # stay limited to explicitly ephemeral benchmark/test profiles.
+    command: postgres -c checkpoint_timeout=600 -c max_wal_size=4096
     <<: *common-logging
 
   nginx:


### PR DESCRIPTION
## Summary
- align `compose.yaml` with the Hostinger production observability topology by adding pinned LGTM + OTEL Collector services
- point local/default app services at `otel-collector` while preserving app/db/nginx local port mappings
- simplify `compose.override.yaml` into the development scope: Debug builds plus published Grafana/OTLP ports for local inspection/tools

## Test Plan
- [x] `git diff --check`
- [x] `docker compose -f compose.yaml config --quiet`
- [x] `docker compose -f compose.yaml -f compose.override.yaml config --quiet`
- [x] rendered dev compose contains `otel-collector`, `otel-lgtm`, `OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317`, collector config mount, and published dev ports `3000`, `4317`, `4318`
- [x] `docker compose --env-file .env.hostinger.example -f compose.prod.yaml config --quiet`
- [x] `dotnet test test/Architecture.Tests/Architecture.Tests.csproj --nologo` — 25 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added observability infrastructure with OpenTelemetry and Grafana LGTM for monitoring
  * Updated PostgreSQL with improved healthcheck and configuration parameters
  * Updated nginx to version 1.27-alpine
  * Enhanced logging configuration across services
  * Reorganized service startup dependencies for better orchestration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->