### PR TITLE
ci: deploy Hostinger after amd64 images

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -290,7 +290,9 @@ jobs:
   deploy-hostinger:
     name: Deploy to Hostinger Docker Manager
     if: ${{ github.event_name == 'push' || inputs.deploy_hostinger }}
-    needs: [container-test, merge-manifest]
+    # Hostinger runs on amd64; deploy as soon as amd64 images and container
+    # healthchecks pass instead of waiting for slow arm64 multi-arch manifests.
+    needs: [container-test, build-push-amd64]
     runs-on: ubuntu-latest
     environment: production-hostinger
     env:


### PR DESCRIPTION
## Summary
- deploy Hostinger after amd64 images and container checks pass
- avoid blocking Hostinger deploys on slow arm64 manifest builds

## Test Plan
- [x] workflow YAML lint via patch tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment pipeline job dependencies for faster deployment execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->