### PR TITLE
fix: deploy Hostinger amd64 image tags

### DIFF
--- a/scripts/deploy-hostinger-docker-manager.sh
+++ b/scripts/deploy-hostinger-docker-manager.sh
@@ -25,7 +25,10 @@ if [[ ! "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
   exit 1
 fi
 
-tag="sha-${GITHUB_SHA}"
+# Hostinger VPS currently runs amd64 images. The multi-arch sha-${GITHUB_SHA}
+# manifest is created later by merge-manifest; deploy from the immutable amd64
+# tags that already exist when this job starts.
+tag="sha-${GITHUB_SHA}-amd64"
 web_api_image="ghcr.io/jonathanperis/cpnucleo-web-api:${tag}"
 identity_api_image="ghcr.io/jonathanperis/cpnucleo-identity-api:${tag}"
 grpc_server_image="ghcr.io/jonathanperis/cpnucleo-grpc-server:${tag}"


### PR DESCRIPTION
## Summary
- deploy Hostinger from immutable `sha-<commit>-amd64` tags
- keep Hostinger deploy decoupled from slower multi-arch manifest creation

## Test Plan
- [x] `bash -n scripts/deploy-hostinger-docker-manager.sh`
- [x] `git diff --check`
