### PR TITLE
fix: make Hostinger open link target WebClient

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -51,6 +51,34 @@ x-common-logging: &common-logging
       max-file: "3"
 
 services:
+  # Hostinger Docker Manager derives the project-level "Open" link from a
+  # reachable project container. Keep this tiny redirect container first and
+  # published so that panel clicks land on the canonical WebClient domain
+  # instead of an internal application port such as gRPC.
+  aaa-open-cpnucleo:
+    image: nginx:1.27-alpine
+    container_name: aaa-open-cpnucleo
+    configs:
+      - source: hostinger_open_redirect_config
+        target: /etc/nginx/conf.d/default.conf
+    ports:
+      - "${HOSTINGER_OPEN_REDIRECT_PORT:-1080}:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: "0.05"
+          memory: "32M"
+        reservations:
+          cpus: "0.01"
+          memory: "16M"
+    <<: *common-logging
+
   otel-lgtm:
     image: grafana/otel-lgtm:0.11.10
     container_name: otel-lgtm-cpnucleo
@@ -278,6 +306,22 @@ volumes:
       - "com.example.service=cpnucleo-db"
 
 configs:
+  hostinger_open_redirect_config:
+    content: |
+      server {
+          listen 8080;
+          server_name _;
+
+          location = /healthz {
+              access_log off;
+              add_header Content-Type text/plain;
+              return 200 'Healthy';
+          }
+
+          location / {
+              return 302 https://cpnucleo.jonathanperis.tech$$request_uri;
+          }
+      }
   otel_collector_config:
     content: |
       # Production OpenTelemetry Collector gateway for the single-VPS Hostinger stack.

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -62,7 +62,7 @@ services:
       - source: hostinger_open_redirect_config
         target: /etc/nginx/conf.d/default.conf
     ports:
-      - "${HOSTINGER_OPEN_REDIRECT_PORT:-1080}:8080"
+      - "3000:8080"
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/healthz"]
       interval: 30s

--- a/scripts/deploy-hostinger-docker-manager.sh
+++ b/scripts/deploy-hostinger-docker-manager.sh
@@ -36,6 +36,7 @@ web_client_image="ghcr.io/jonathanperis/cpnucleo-web-client:${tag}"
 compose_url="https://raw.githubusercontent.com/${PROJECT_OWNER_REPO}/${GITHUB_SHA}/compose.prod.yaml"
 
 expected_containers=(
+  aaa-open-cpnucleo
   otel-lgtm-cpnucleo
   otel-collector-cpnucleo
   webapi1-cpnucleo


### PR DESCRIPTION
## Summary
- Add a tiny `aaa-open-cpnucleo` nginx redirect container for Hostinger Docker Manager's project-level Open link.
- Publish only that redirect helper on host port 1080 so panel Open lands on the canonical WebClient domain instead of the gRPC service.
- Include the redirect helper in Hostinger deploy container verification.

## Test Plan
- [x] `bash -n scripts/deploy-hostinger-docker-manager.sh`
- [x] `docker compose --env-file /tmp/cpnucleo-compose.env -f compose.prod.yaml config --quiet`
- [x] `git diff --check`
- [ ] `dotnet test test/Architecture.Tests/` — not runnable in this environment: `dotnet` is not installed
- [ ] `docker run ... nginx -t` — not runnable in this environment: Docker daemon is unavailable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new redirect service that automatically routes incoming requests to the canonical URL with integrated health monitoring capabilities to ensure continuous availability.

* **Chores**
  * Updated deployment verification procedures to include health checks for the new redirect service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->