### PR TITLE
chore: remove Hostinger open redirect helper

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -51,34 +51,6 @@ x-common-logging: &common-logging
       max-file: "3"
 
 services:
-  # Hostinger Docker Manager derives the project-level "Open" link from a
-  # reachable project container. Keep this tiny redirect container first and
-  # published so that panel clicks land on the canonical WebClient domain
-  # instead of an internal application port such as gRPC.
-  aaa-open-cpnucleo:
-    image: nginx:1.27-alpine
-    container_name: aaa-open-cpnucleo
-    configs:
-      - source: hostinger_open_redirect_config
-        target: /etc/nginx/conf.d/default.conf
-    ports:
-      - "3000:8080"
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8080/healthz"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    restart: always
-    deploy:
-      resources:
-        limits:
-          cpus: "0.05"
-          memory: "32M"
-        reservations:
-          cpus: "0.01"
-          memory: "16M"
-    <<: *common-logging
-
   otel-lgtm:
     image: grafana/otel-lgtm:0.11.10
     container_name: otel-lgtm-cpnucleo
@@ -306,22 +278,6 @@ volumes:
       - "com.example.service=cpnucleo-db"
 
 configs:
-  hostinger_open_redirect_config:
-    content: |
-      server {
-          listen 8080;
-          server_name _;
-
-          location = /healthz {
-              access_log off;
-              add_header Content-Type text/plain;
-              return 200 'Healthy';
-          }
-
-          location / {
-              return 302 https://cpnucleo.jonathanperis.tech$$request_uri;
-          }
-      }
   otel_collector_config:
     content: |
       # Production OpenTelemetry Collector gateway for the single-VPS Hostinger stack.

--- a/scripts/deploy-hostinger-docker-manager.sh
+++ b/scripts/deploy-hostinger-docker-manager.sh
@@ -36,7 +36,6 @@ web_client_image="ghcr.io/jonathanperis/cpnucleo-web-client:${tag}"
 compose_url="https://raw.githubusercontent.com/${PROJECT_OWNER_REPO}/${GITHUB_SHA}/compose.prod.yaml"
 
 expected_containers=(
-  aaa-open-cpnucleo
   otel-lgtm-cpnucleo
   otel-collector-cpnucleo
   webapi1-cpnucleo


### PR DESCRIPTION
## Summary
- Remove the `aaa-open-cpnucleo` Hostinger Docker Manager open-link redirect helper from production compose
- Remove the helper from Hostinger deployment expected-container verification

## Test Plan
- [x] Parsed `compose.prod.yaml` with `js-yaml` and verified the helper service/config are absent while core production services remain
- [x] `bash -n scripts/deploy-hostinger-docker-manager.sh`
- [x] `git diff --check`
- [x] `DOTNET_CLI_HOME=/opt/data DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 dotnet test test/Architecture.Tests/Architecture.Tests.csproj --configuration Release`

## Notes
- Docker Compose CLI/plugin is not installed in this local environment, so full `docker compose config` validation was not available here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Hostinger "open" redirect service infrastructure and associated configuration from production deployment
  * Updated deployment health check verification script to reflect removal of the redirect service

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->