### PR TITLE
chore: align FastEndpoints phase 1 setup

### DIFF
--- a/src/IdentityApi/Endpoints/Login/Endpoint.cs
+++ b/src/IdentityApi/Endpoints/Login/Endpoint.cs
@@ -4,7 +4,7 @@ public class Endpoint(IApplicationDbContext dbContext, IPasswordHasher passwordH
 {
     public override void Configure()
     {
-        Post("/api/login");
+        Post("/login");
         Description(x => x.WithTags("Authentication"));
         AllowAnonymous();
 

--- a/src/IdentityApi/IdentityApi.csproj
+++ b/src/IdentityApi/IdentityApi.csproj
@@ -46,6 +46,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/IdentityApi/IdentityApi.csproj
+++ b/src/IdentityApi/IdentityApi.csproj
@@ -41,7 +41,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="FastEndpoints.Security" Version="8.1.0" />
-        <PackageReference Include="FastEndpoints.Swagger" Version="7.2.0" />
+        <PackageReference Include="FastEndpoints.Swagger" Version="8.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -9,8 +9,7 @@ builder.ConfigureOpenTelemetry();
 
 builder.Services
     .AddAuthenticationJwtBearer(s => s.SigningKey = builder.Configuration["Jwt:SigningKey"] ?? throw new InvalidOperationException("Jwt:SigningKey configuration is missing."))
-    .AddAuthorization() 
-    .AddFastEndpoints();
+    .AddAuthorization();
 
 builder.Services
     .Configure<JwtCreationOptions>(o =>
@@ -58,7 +57,6 @@ builder.Services.AddOutputCache(options =>
 builder.Services.AddHealthChecks();
 
 builder.Services
-    // .AddFastEndpoints(o => o.SourceGeneratorDiscoveredTypes = WebApi.DiscoveredTypes.All)
     .AddFastEndpoints()
     .SwaggerDocument(o =>
     {

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -81,7 +81,7 @@ app.UseInfrastructure();
 
 app.UseAuthentication()
     .UseAuthorization()
-    .UseFastEndpoints()
+    .UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api")
         .UseMiddleware<ElapsedTimeMiddleware>()
         .UseMiddleware<ErrorHandlingMiddleware>();
 

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -29,7 +29,7 @@ builder.Services.AddRateLimiter(options =>
             {
                 PermitLimit = 10, // Allow 10 requests
                 Window = TimeSpan.FromMinutes(1), // Per 1-minute window
-                QueueLimit = 3, // Queue up to 10 additional requests
+                QueueLimit = 5, // Queue up to 5 additional requests
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst, // Process oldest requests first
                 AutoReplenishment = true // Default: automatically replenish permits
             }));

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Dapper.AOT" Version="1.0.48" />
     <PackageReference Include="Delta" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/WebApi/Endpoints/Appointment/CreateAppointment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Appointment/CreateAppointment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/appointment");
+        Post("/appointment");
         Description(x => x.WithTags("Appointments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Appointment/GetAppointmentById/Endpoint.cs
+++ b/src/WebApi/Endpoints/Appointment/GetAppointmentById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/appointment");
+        Get("/appointment");
         Description(x => x.WithTags("Appointments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Appointment/ListAppointments/Endpoint.cs
+++ b/src/WebApi/Endpoints/Appointment/ListAppointments/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/appointments");
+        Get("/appointments");
         Description(x => x.WithTags("Appointments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Appointment/RemoveAppointment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Appointment/RemoveAppointment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAppointm
 {
     public override void Configure()
     {
-        Delete("/api/appointment");
+        Delete("/appointment");
         Description(x => x.WithTags("Appointments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Appointment/UpdateAppointment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Appointment/UpdateAppointment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/appointment");
+        Patch("/appointment");
         Description(x => x.WithTags("Appointments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Assignment/CreateAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/CreateAssignment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/assignment");
+        Post("/assignment");
         Description(x => x.WithTags("Assignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Assignment/GetAssignmentById/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/GetAssignmentById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/assignment");
+        Get("/assignment");
         Description(x => x.WithTags("Assignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Assignment/ListAssignments/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/ListAssignments/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/assignments");
+        Get("/assignments");
         Description(x => x.WithTags("Assignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Assignment/RemoveAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/RemoveAssignment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAssignme
 {
     public override void Configure()
     {
-        Delete("/api/assignment");
+        Delete("/assignment");
         Description(x => x.WithTags("Assignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Assignment/UpdateAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/UpdateAssignment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/assignment");
+        Patch("/assignment");
         Description(x => x.WithTags("Assignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentImpediment/CreateAssignmentImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/CreateAssignmentImpediment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/assignmentImpediment");
+        Post("/assignmentImpediment");
         Description(x => x.WithTags("AssignmentImpediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentImpediment/GetAssignmentImpedimentById/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/GetAssignmentImpedimentById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/assignmentImpediment");
+        Get("/assignmentImpediment");
         Description(x => x.WithTags("AssignmentImpediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentImpediment/ListAssignmentImpediments/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/ListAssignmentImpediments/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/assignmentImpediments");
+        Get("/assignmentImpediments");
         Description(x => x.WithTags("AssignmentImpediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentImpediment/RemoveAssignmentImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/RemoveAssignmentImpediment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAssignme
 {
     public override void Configure()
     {
-        Delete("/api/assignmentImpediment");
+        Delete("/assignmentImpediment");
         Description(x => x.WithTags("AssignmentImpediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentImpediment/UpdateAssignmentImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/UpdateAssignmentImpediment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/assignmentImpediment");
+        Patch("/assignmentImpediment");
         Description(x => x.WithTags("AssignmentImpediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentType/CreateAssignmentType/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/CreateAssignmentType/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/assignmentType");
+        Post("/assignmentType");
         Description(x => x.WithTags("AssignmentTypes"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentType/GetAssignmentTypeById/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/GetAssignmentTypeById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/assignmentType");
+        Get("/assignmentType");
         Description(x => x.WithTags("AssignmentTypes"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentType/ListAssignmentTypes/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/ListAssignmentTypes/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/assignmentTypes");
+        Get("/assignmentTypes");
         Description(x => x.WithTags("AssignmentTypes"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentType/RemoveAssignmentType/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/RemoveAssignmentType/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAssignme
 {
     public override void Configure()
     {
-        Delete("/api/assignmentType");
+        Delete("/assignmentType");
         Description(x => x.WithTags("AssignmentTypes"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/AssignmentType/UpdateAssignmentType/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/UpdateAssignmentType/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/assignmentType");
+        Patch("/assignmentType");
         Description(x => x.WithTags("AssignmentTypes"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Impediment/CreateImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/CreateImpediment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/impediment");
+        Post("/impediment");
         Description(x => x.WithTags("Impediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Impediment/GetImpedimentById/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/GetImpedimentById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Get("/api/impediment");
+        Get("/impediment");
         Description(x => x.WithTags("Impediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Impediment/ListImpediments/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/ListImpediments/Endpoint.cs
@@ -12,7 +12,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
     
     public override void Configure()
     {
-        Get("/api/impediments");
+        Get("/impediments");
         Description(x => x.WithTags("Impediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Impediment/RemoveImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/RemoveImpediment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveImpedime
 {
     public override void Configure()
     {
-        Delete("/api/impediment");
+        Delete("/impediment");
         Description(x => x.WithTags("Impediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Impediment/UpdateImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/UpdateImpediment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/impediment");
+        Patch("/impediment");
         Description(x => x.WithTags("Impediments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Organization/CreateOrganization/Endpoint.cs
+++ b/src/WebApi/Endpoints/Organization/CreateOrganization/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Post("/api/organization");
+        Post("/organization");
         Description(x => x.WithTags("Organizations"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Organization/GetOrganizationById/Endpoint.cs
+++ b/src/WebApi/Endpoints/Organization/GetOrganizationById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/organization");
+        Get("/organization");
         Description(x => x.WithTags("Organizations"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Organization/ListOrganizations/Endpoint.cs
+++ b/src/WebApi/Endpoints/Organization/ListOrganizations/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/organizations");
+        Get("/organizations");
         Description(x => x.WithTags("Organizations"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Organization/ListOrganizations/Models.cs
+++ b/src/WebApi/Endpoints/Organization/ListOrganizations/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of organizations.
     /// </summary>
-    public PaginatedResult<OrganizationDto?> Result { get; set; }
+    public PaginatedResult<OrganizationDto?> Result { get; set; } = default!;
 }

--- a/src/WebApi/Endpoints/Organization/RemoveOrganization/Endpoint.cs
+++ b/src/WebApi/Endpoints/Organization/RemoveOrganization/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<RemoveOrganizationReque
 {
     public override void Configure()
     {
-        Delete("/api/organization");
+        Delete("/organization");
         Description(x => x.WithTags("Organizations"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Organization/UpdateOrganization/Endpoint.cs
+++ b/src/WebApi/Endpoints/Organization/UpdateOrganization/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Patch("/api/organization");
+        Patch("/organization");
         Description(x => x.WithTags("Organizations"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Project/CreateProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/Project/CreateProject/Endpoint.cs
@@ -4,7 +4,7 @@ public class Endpoint(CreateProjectHandler handler) : Endpoint<Request, Response
 {
     public override void Configure()
     {
-        Post("/api/project");
+        Post("/project");
         Description(x => x.WithTags("Projects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Project/GetProjectById/Endpoint.cs
+++ b/src/WebApi/Endpoints/Project/GetProjectById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IProjectRepository repository) : Endpoint<Request, Respons
 {
     public override void Configure()
     {
-        Get("/api/project");
+        Get("/project");
         Description(x => x.WithTags("Projects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Project/ListProjects/Endpoint.cs
+++ b/src/WebApi/Endpoints/Project/ListProjects/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IProjectRepository repository) : Endpoint<Request, Respons
 {
     public override void Configure()
     {
-        Get("/api/projects");
+        Get("/projects");
         Description(x => x.WithTags("Projects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Project/RemoveProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/Project/RemoveProject/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IProjectRepository repository) : Endpoint<RemoveProjectReq
 {
     public override void Configure()
     {
-        Delete("/api/project");
+        Delete("/project");
         Description(x => x.WithTags("Projects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Project/UpdateProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/Project/UpdateProject/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IProjectRepository repository) : Endpoint<Request, Respons
 {
     public override void Configure()
     {
-        Patch("/api/project");
+        Patch("/project");
         Description(x => x.WithTags("Projects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/User/CreateUser/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/CreateUser/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext, IPasswordHasher passwordH
 {
     public override void Configure()
     {
-        Post("/api/user");
+        Post("/user");
         Description(x => x.WithTags("Users"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/User/GetUserById/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/GetUserById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/user");
+        Get("/user");
         Description(x => x.WithTags("Users"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/User/ListUsers/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/ListUsers/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/users");
+        Get("/users");
         Description(x => x.WithTags("Users"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/User/RemoveUser/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/RemoveUser/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveUserRequ
 {
     public override void Configure()
     {
-        Delete("/api/user");
+        Delete("/user");
         Description(x => x.WithTags("Users"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/User/UpdateUser/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/UpdateUser/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext, IPasswordHasher passwordH
 {
     public override void Configure()
     {
-        Patch("/api/user");
+        Patch("/user");
         Description(x => x.WithTags("Users"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserAssignment/CreateUserAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/CreateUserAssignment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/userAssignment");
+        Post("/userAssignment");
         Description(x => x.WithTags("UserAssignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserAssignment/GetUserAssignmentById/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/GetUserAssignmentById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/userAssignment");
+        Get("/userAssignment");
         Description(x => x.WithTags("UserAssignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserAssignment/ListUserAssignments/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/ListUserAssignments/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/userAssignments");
+        Get("/userAssignments");
         Description(x => x.WithTags("UserAssignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserAssignment/RemoveUserAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/RemoveUserAssignment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveUserAssi
 {
     public override void Configure()
     {
-        Delete("/api/userAssignment");
+        Delete("/userAssignment");
         Description(x => x.WithTags("UserAssignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserAssignment/UpdateUserAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/UpdateUserAssignment/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/userAssignment");
+        Patch("/userAssignment");
         Description(x => x.WithTags("UserAssignments"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserProject/CreateUserProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/CreateUserProject/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/userProject");
+        Post("/userProject");
         Description(x => x.WithTags("UserProjects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserProject/GetUserProjectById/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/GetUserProjectById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/userProject");
+        Get("/userProject");
         Description(x => x.WithTags("UserProjects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserProject/ListUserProjects/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/ListUserProjects/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/userProjects");
+        Get("/userProjects");
         Description(x => x.WithTags("UserProjects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserProject/RemoveUserProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/RemoveUserProject/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveUserProj
 {
     public override void Configure()
     {
-        Delete("/api/userProject");
+        Delete("/userProject");
         Description(x => x.WithTags("UserProjects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/UserProject/UpdateUserProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/UpdateUserProject/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/userProject");
+        Patch("/userProject");
         Description(x => x.WithTags("UserProjects"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Workflow/CreateWorkflow/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/CreateWorkflow/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Post("/api/workflow");
+        Post("/workflow");
         Description(x => x.WithTags("Workflows"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Workflow/GetWorkflowById/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/GetWorkflowById/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/workflow");
+        Get("/workflow");
         Description(x => x.WithTags("Workflows"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Workflow/ListWorkflows/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/ListWorkflows/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
 {
     public override void Configure()
     {
-        Get("/api/workflows");
+        Get("/workflows");
         Description(x => x.WithTags("Workflows"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Workflow/RemoveWorkflow/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/RemoveWorkflow/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveWorkflow
 {
     public override void Configure()
     {
-        Delete("/api/workflow");
+        Delete("/workflow");
         Description(x => x.WithTags("Workflows"));
         AllowAnonymous();
 

--- a/src/WebApi/Endpoints/Workflow/UpdateWorkflow/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/UpdateWorkflow/Endpoint.cs
@@ -5,7 +5,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
 {
     public override void Configure()
     {
-        Patch("/api/workflow");
+        Patch("/workflow");
         Description(x => x.WithTags("Workflows"));
         AllowAnonymous();
 

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -78,7 +78,7 @@ app.UseHealthChecks("/healthz");
 app.UseInfrastructure();
 
 app.
-    UseFastEndpoints()
+    UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api")
     .UseMiddleware<ElapsedTimeMiddleware>()
     .UseMiddleware<ErrorHandlingMiddleware>();
 

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -41,7 +41,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FastEndpoints.Swagger" Version="7.2.0" />
+		<PackageReference Include="FastEndpoints.Swagger" Version="8.1.0" />
 		<PackageReference Include="Microsoft.AspnetCore.Authentication.JwtBearer" Version="10.0.7" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -47,6 +47,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+        <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.1" />
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
         <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
 	</ItemGroup>

--- a/tests/Architecture.Tests/Architecture.Tests.csproj
+++ b/tests/Architecture.Tests/Architecture.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -1,33 +1,46 @@
 namespace Architecture.Tests;
 
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Xml.Linq;
 
 public class FastEndpointsConfigurationTests
 {
     private static readonly string[] HttpVerbRouteMethods = ["Get", "Post", "Put", "Delete", "Patch"];
 
-    [Theory]
-    [InlineData("src/WebApi/WebApi.csproj")]
-    [InlineData("src/IdentityApi/IdentityApi.csproj")]
-    [InlineData("tests/WebApi.Integration.Tests/WebApi.Integration.Tests.csproj")]
-    public void FastEndpointsPackageVersions_ShouldBeAligned(string projectPath)
+    [Fact]
+    public void FastEndpointsPackageVersions_ShouldBeAligned()
     {
-        var project = XDocument.Load(GetRepositoryPath(projectPath));
-        var fastEndpointsPackageVersions = project
-            .Descendants("PackageReference")
-            .Where(x => x.Attribute("Include")?.Value.StartsWith("FastEndpoints", StringComparison.Ordinal) == true)
-            .Select(x => x.Attribute("Version")!.Value)
-            .Distinct()
+        var repositoryRoot = GetRepositoryPath(".");
+        var fastEndpointsPackageVersions = Directory
+            .EnumerateFiles(repositoryRoot, "*.csproj", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .SelectMany(projectPath => XDocument
+                .Load(projectPath)
+                .Descendants("PackageReference")
+                .Where(x => x.Attribute("Include")?.Value.StartsWith("FastEndpoints", StringComparison.Ordinal) == true)
+                .Select(x => new
+                {
+                    ProjectPath = Path.GetRelativePath(repositoryRoot, projectPath),
+                    Version = x.Attribute("Version")?.Value
+                }))
             .ToArray();
 
-        fastEndpointsPackageVersions.Should().Equal("8.1.0");
+        fastEndpointsPackageVersions.Should().NotBeEmpty();
+        fastEndpointsPackageVersions
+            .Select(x => x.Version)
+            .Distinct()
+            .Should()
+            .ContainSingle("all FastEndpoints packages should use the same reviewed version: {0}", string.Join(", ", fastEndpointsPackageVersions.Select(x => $"{x.ProjectPath}: {x.Version}")))
+            .Which.Should().Be("8.1.0");
     }
 
     [Fact]
     public void IdentityApi_ShouldRegisterFastEndpointsOnce()
     {
         var program = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Program.cs"));
-        var registrationCount = CountOccurrences(program, ".AddFastEndpoints(");
+        var registrationCount = CountInvocationExpressions(program, "AddFastEndpoints");
 
         registrationCount.Should().Be(1);
     }
@@ -70,17 +83,18 @@ public class FastEndpointsConfigurationTests
         return Path.Combine(directory!.FullName, relativePath);
     }
 
-    private static int CountOccurrences(string value, string search)
+    private static int CountInvocationExpressions(string value, string methodName)
     {
-        var count = 0;
-        var index = 0;
+        var root = CSharpSyntaxTree.ParseText(value).GetRoot();
 
-        while ((index = value.IndexOf(search, index, StringComparison.Ordinal)) >= 0)
-        {
-            count++;
-            index += search.Length;
-        }
-
-        return count;
+        return root
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Count(invocation => invocation.Expression switch
+            {
+                IdentifierNameSyntax identifier => identifier.Identifier.ValueText == methodName,
+                MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText == methodName,
+                _ => false
+            });
     }
 }

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -4,6 +4,8 @@ using System.Xml.Linq;
 
 public class FastEndpointsConfigurationTests
 {
+    private static readonly string[] HttpVerbRouteMethods = ["Get", "Post", "Put", "Delete", "Patch"];
+
     [Theory]
     [InlineData("src/WebApi/WebApi.csproj")]
     [InlineData("src/IdentityApi/IdentityApi.csproj")]
@@ -28,6 +30,30 @@ public class FastEndpointsConfigurationTests
         var registrationCount = CountOccurrences(program, ".AddFastEndpoints(");
 
         registrationCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("src/WebApi/Program.cs")]
+    [InlineData("src/IdentityApi/Program.cs")]
+    public void ApiProjects_ShouldUseGlobalFastEndpointsApiRoutePrefix(string programPath)
+    {
+        var program = File.ReadAllText(GetRepositoryPath(programPath));
+
+        program.Should().Contain("UseFastEndpoints(c => c.Endpoints.RoutePrefix = \"api\")");
+    }
+
+    [Theory]
+    [InlineData("src/WebApi/Endpoints")]
+    [InlineData("src/IdentityApi/Endpoints")]
+    public void FastEndpoints_ShouldNotHardCodeApiRoutePrefix(string endpointsPath)
+    {
+        var endpointFiles = Directory.GetFiles(GetRepositoryPath(endpointsPath), "*.cs", SearchOption.AllDirectories);
+        var filesWithHardCodedPrefix = endpointFiles
+            .Where(path => HttpVerbRouteMethods.Any(method => File.ReadAllText(path).Contains($"{method}(\"/api", StringComparison.Ordinal)))
+            .Select(path => Path.GetRelativePath(GetRepositoryPath("."), path))
+            .ToArray();
+
+        filesWithHardCodedPrefix.Should().BeEmpty();
     }
 
     private static string GetRepositoryPath(string relativePath)

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -1,0 +1,60 @@
+namespace Architecture.Tests;
+
+using System.Xml.Linq;
+
+public class FastEndpointsConfigurationTests
+{
+    [Theory]
+    [InlineData("src/WebApi/WebApi.csproj")]
+    [InlineData("src/IdentityApi/IdentityApi.csproj")]
+    [InlineData("tests/WebApi.Integration.Tests/WebApi.Integration.Tests.csproj")]
+    public void FastEndpointsPackageVersions_ShouldBeAligned(string projectPath)
+    {
+        var project = XDocument.Load(GetRepositoryPath(projectPath));
+        var fastEndpointsPackageVersions = project
+            .Descendants("PackageReference")
+            .Where(x => x.Attribute("Include")?.Value.StartsWith("FastEndpoints", StringComparison.Ordinal) == true)
+            .Select(x => x.Attribute("Version")!.Value)
+            .Distinct()
+            .ToArray();
+
+        fastEndpointsPackageVersions.Should().Equal("8.1.0");
+    }
+
+    [Fact]
+    public void IdentityApi_ShouldRegisterFastEndpointsOnce()
+    {
+        var program = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Program.cs"));
+        var registrationCount = CountOccurrences(program, ".AddFastEndpoints(");
+
+        registrationCount.Should().Be(1);
+    }
+
+    private static string GetRepositoryPath(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "cpnucleo.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the test should run from inside the cpnucleo repository output tree");
+
+        return Path.Combine(directory!.FullName, relativePath);
+    }
+
+    private static int CountOccurrences(string value, string search)
+    {
+        var count = 0;
+        var index = 0;
+
+        while ((index = value.IndexOf(search, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += search.Length;
+        }
+
+        return count;
+    }
+}

--- a/tests/WebApi.Integration.Tests/Endpoints/Appointment/RemoveAppointmentTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/Appointment/RemoveAppointmentTests.cs
@@ -11,7 +11,7 @@ public class RemoveAppointmentTests(WebAppFixture app, WebAppState state) : Test
     [Fact, Priority(1)]
     public async Task Appointments_ShouldDeleteAnAppointment()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveAppointmentRequest, ErrorResponse>(new RemoveAppointmentRequest
         {
             Ids = [_appointmentId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/Assignment/RemoveAssignmentTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/Assignment/RemoveAssignmentTests.cs
@@ -11,7 +11,7 @@ public class RemoveAssignmentTests(WebAppFixture app, WebAppState state) : TestB
     [Fact, Priority(1)]
     public async Task Assignments_ShouldDeleteAnAssignment()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveAssignmentRequest, ErrorResponse>(new RemoveAssignmentRequest
         {
             Ids = [_assignmentId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/AssignmentImpediment/RemoveAssignmentImpedimentTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/AssignmentImpediment/RemoveAssignmentImpedimentTests.cs
@@ -11,7 +11,7 @@ public class RemoveAssignmentImpedimentTests(WebAppFixture app, WebAppState stat
     [Fact, Priority(1)]
     public async Task AssignmentImpediments_ShouldDeleteAnAssignmentImpediment()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveAssignmentImpedimentRequest, ErrorResponse>(new RemoveAssignmentImpedimentRequest
         {
             Ids = [_assignmentImpedimentId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/AssignmentType/RemoveAssignmentTypeTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/AssignmentType/RemoveAssignmentTypeTests.cs
@@ -11,7 +11,7 @@ public class RemoveAssignmentTypeTests(WebAppFixture app, WebAppState state) : T
     [Fact, Priority(1)]
     public async Task AssignmentTypes_ShouldDeleteAnAssignmentType()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveAssignmentTypeRequest, ErrorResponse>(new RemoveAssignmentTypeRequest
         {
             Ids = [_assignmentTypeId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/Impediment/RemoveImpedimentTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/Impediment/RemoveImpedimentTests.cs
@@ -11,7 +11,7 @@ public class RemoveImpedimentTests(WebAppFixture app, WebAppState state) : TestB
     [Fact, Priority(1)]
     public async Task Impediments_ShouldDeleteAnImpediment()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveImpedimentRequest, ErrorResponse>(new RemoveImpedimentRequest
         {
             Ids = [_impedimentId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/Organization/RemoveOrganizationTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/Organization/RemoveOrganizationTests.cs
@@ -11,7 +11,7 @@ public class RemoveOrganizationTests(WebAppFixture app, WebAppState state) : Tes
     [Fact, Priority(1)]
     public async Task Organizations_ShouldDeleteAnOrganization()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveOrganizationRequest, ErrorResponse>(new RemoveOrganizationRequest
         {
             Ids = [_organizationId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/Project/RemoveProjectTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/Project/RemoveProjectTests.cs
@@ -11,7 +11,7 @@ public class RemoveProjectTests(WebAppFixture app, WebAppState state) : TestBase
     [Fact, Priority(1)]
     public async Task Projects_ShouldDeleteAnProject()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveProjectRequest, ErrorResponse>(new RemoveProjectRequest
         {
             Ids = [_projectId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/User/RemoveUserTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/User/RemoveUserTests.cs
@@ -11,7 +11,7 @@ public class RemoveUserTests(WebAppFixture app, WebAppState state) : TestBase<We
     [Fact, Priority(1)]
     public async Task Users_ShouldDeleteAnUser()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveUserRequest, ErrorResponse>(new RemoveUserRequest
         {
             Ids = [_userId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/UserAssignment/RemoveUserAssignmentTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/UserAssignment/RemoveUserAssignmentTests.cs
@@ -11,7 +11,7 @@ public class RemoveUserAssignmentTests(WebAppFixture app, WebAppState state) : T
     [Fact, Priority(1)]
     public async Task UserAssignments_ShouldDeleteAnUserAssignment()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveUserAssignmentRequest, ErrorResponse>(new RemoveUserAssignmentRequest
         {
             Ids = [_userAssignmentId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/UserProject/RemoveUserProjectTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/UserProject/RemoveUserProjectTests.cs
@@ -11,7 +11,7 @@ public class RemoveUserProjectTests(WebAppFixture app, WebAppState state) : Test
     [Fact, Priority(1)]
     public async Task UserProjects_ShouldDeleteAnUserProject()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveUserProjectRequest, ErrorResponse>(new RemoveUserProjectRequest
         {
             Ids = [_userProjectId]
         });

--- a/tests/WebApi.Integration.Tests/Endpoints/Workflow/RemoveWorkflowTests.cs
+++ b/tests/WebApi.Integration.Tests/Endpoints/Workflow/RemoveWorkflowTests.cs
@@ -11,7 +11,7 @@ public class RemoveWorkflowTests(WebAppFixture app, WebAppState state) : TestBas
     [Fact, Priority(1)]
     public async Task Workflows_ShouldDeleteAnWorkflow()
     {
-        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, Request, ErrorResponse>(new Request
+        var (rsp, err) = await app.Client.DELETEAsync<Endpoint, RemoveWorkflowRequest, ErrorResponse>(new RemoveWorkflowRequest
         {
             Ids = [_workflowId]
         });

--- a/tests/WebApi.Integration.Tests/WebApi.Integration.Tests.csproj
+++ b/tests/WebApi.Integration.Tests/WebApi.Integration.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="FastEndpoints.Testing" Version="7.2.0" />
+      <PackageReference Include="FastEndpoints.Testing" Version="8.1.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
       <PackageReference Include="Shouldly" Version="4.3.0" />
       <PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/tests/WebApi.Unit.Tests/Endpoints/ImpedimentEndpointsTests.cs
+++ b/tests/WebApi.Unit.Tests/Endpoints/ImpedimentEndpointsTests.cs
@@ -13,13 +13,11 @@ public class ImpedimentEndpointsTests
         var impedimentId = Guid.NewGuid();
         var impediment = Impediment.Create("Test Impediment", impedimentId);
         
-        var fakeDbContext = A.Fake<IApplicationDbContext>();
-        var fakeDbSet = A.Fake<DbSet<Impediment>>();
-        
-        A.CallTo(() => fakeDbContext.Impediments).Returns(fakeDbSet);
-        A.CallTo(() => fakeDbSet.FindAsync(A<object[]>._, A<CancellationToken>._)).Returns(new ValueTask<Impediment?>(impediment));
+        await using var dbContext = CreateDbContext();
+        dbContext.Impediments!.Add(impediment);
+        await dbContext.SaveChangesAsync(default);
 
-        var ep = Factory.Create<WebApi.Endpoints.Impediment.GetImpedimentById.Endpoint>(fakeDbContext);
+        var ep = Factory.Create<WebApi.Endpoints.Impediment.GetImpedimentById.Endpoint>(dbContext);
         var req = new WebApi.Endpoints.Impediment.GetImpedimentById.Request { Id = impedimentId };
 
         // Act
@@ -38,13 +36,9 @@ public class ImpedimentEndpointsTests
         // Arrange
         var impedimentId = Guid.NewGuid();
         
-        var fakeDbContext = A.Fake<IApplicationDbContext>();
-        var fakeDbSet = A.Fake<DbSet<Impediment>>();
-        
-        A.CallTo(() => fakeDbContext.Impediments).Returns(fakeDbSet);
-        A.CallTo(() => fakeDbSet.FindAsync(A<object[]>._, A<CancellationToken>._)).Returns(new ValueTask<Impediment?>((Impediment?)null));
+        await using var dbContext = CreateDbContext();
 
-        var ep = Factory.Create<WebApi.Endpoints.Impediment.GetImpedimentById.Endpoint>(fakeDbContext);
+        var ep = Factory.Create<WebApi.Endpoints.Impediment.GetImpedimentById.Endpoint>(dbContext);
         var req = new WebApi.Endpoints.Impediment.GetImpedimentById.Request { Id = impedimentId };
 
         // Act
@@ -98,7 +92,7 @@ public class ImpedimentEndpointsTests
         A.CallTo(() => fakeDbContext.SaveChangesAsync(A<CancellationToken>._)).Returns(true);
 
         var ep = Factory.Create<WebApi.Endpoints.Impediment.RemoveImpediment.Endpoint>(fakeDbContext);
-        var req = new WebApi.Endpoints.Impediment.RemoveImpediment.Request { Ids = new List<Guid> { impedimentId } };
+        var req = new WebApi.Endpoints.Impediment.RemoveImpediment.RemoveImpedimentRequest { Ids = new List<Guid> { impedimentId } };
 
         // Act
         await ep.HandleAsync(req, default);
@@ -106,5 +100,14 @@ public class ImpedimentEndpointsTests
         // Assert
         ep.Response.ShouldNotBeNull();
         ep.Response.Success.ShouldBeTrue();
+    }
+
+    private static ApplicationDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
     }
 }

--- a/tests/WebApi.Unit.Tests/Endpoints/OrganizationEndpointsTests.cs
+++ b/tests/WebApi.Unit.Tests/Endpoints/OrganizationEndpointsTests.cs
@@ -131,7 +131,7 @@ public class OrganizationEndpointsTests
         A.CallTo(() => fakeUnitOfWork.GetRepository<Organization>()).Returns(fakeRepository);
 
         var ep = Factory.Create<WebApi.Endpoints.Organization.RemoveOrganization.Endpoint>(fakeUnitOfWork);
-        var req = new WebApi.Endpoints.Organization.RemoveOrganization.Request { Ids = new List<Guid> { organizationId } };
+        var req = new WebApi.Endpoints.Organization.RemoveOrganization.RemoveOrganizationRequest { Ids = new List<Guid> { organizationId } };
 
         // Act
         await ep.HandleAsync(req, default);

--- a/tests/WebApi.Unit.Tests/Endpoints/ProjectEndpointsTests.cs
+++ b/tests/WebApi.Unit.Tests/Endpoints/ProjectEndpointsTests.cs
@@ -172,7 +172,7 @@ public class ProjectEndpointsTests
         A.CallTo(() => fakeRepository.UpdateAsync(A<Project>._)).Returns(Task.FromResult(true));
 
         var ep = Factory.Create<WebApi.Endpoints.Project.RemoveProject.Endpoint>(fakeRepository);
-        var req = new WebApi.Endpoints.Project.RemoveProject.Request { Ids = new List<Guid> { projectId } };
+        var req = new WebApi.Endpoints.Project.RemoveProject.RemoveProjectRequest { Ids = new List<Guid> { projectId } };
 
         // Act
         await ep.HandleAsync(req, default);
@@ -192,7 +192,7 @@ public class ProjectEndpointsTests
         A.CallTo(() => fakeRepository.GetByIdAsync(projectId)).Returns(Task.FromResult<Project?>(null));
 
         var ep = Factory.Create<WebApi.Endpoints.Project.RemoveProject.Endpoint>(fakeRepository);
-        var req = new WebApi.Endpoints.Project.RemoveProject.Request { Ids = new List<Guid> { projectId } };
+        var req = new WebApi.Endpoints.Project.RemoveProject.RemoveProjectRequest { Ids = new List<Guid> { projectId } };
 
         // Act
         await ep.HandleAsync(req, default);

--- a/tests/WebApi.Unit.Tests/Endpoints/UserEndpointsTests.cs
+++ b/tests/WebApi.Unit.Tests/Endpoints/UserEndpointsTests.cs
@@ -145,7 +145,7 @@ public class UserEndpointsTests
         A.CallTo(() => fakeDbContext.SaveChangesAsync(A<CancellationToken>._)).Returns(true);
 
         var ep = Factory.Create<WebApi.Endpoints.User.RemoveUser.Endpoint>(fakeDbContext);
-        var req = new WebApi.Endpoints.User.RemoveUser.Request { Ids = new List<Guid> { userId } };
+        var req = new WebApi.Endpoints.User.RemoveUser.RemoveUserRequest { Ids = new List<Guid> { userId } };
 
         // Act
         await ep.HandleAsync(req, default);

--- a/tests/WebApi.Unit.Tests/Endpoints/WorkflowEndpointsTests.cs
+++ b/tests/WebApi.Unit.Tests/Endpoints/WorkflowEndpointsTests.cs
@@ -135,7 +135,7 @@ public class WorkflowEndpointsTests
         A.CallTo(() => fakeDbContext.SaveChangesAsync(A<CancellationToken>._)).Returns(true);
 
         var ep = Factory.Create<WebApi.Endpoints.Workflow.RemoveWorkflow.Endpoint>(fakeDbContext);
-        var req = new WebApi.Endpoints.Workflow.RemoveWorkflow.Request { Ids = new List<Guid> { workflowId } };
+        var req = new WebApi.Endpoints.Workflow.RemoveWorkflow.RemoveWorkflowRequest { Ids = new List<Guid> { workflowId } };
 
         // Act
         await ep.HandleAsync(req, default);

--- a/tests/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj
+++ b/tests/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj
@@ -15,6 +15,7 @@
         </PackageReference>
         <PackageReference Include="FakeItEasy" Version="9.0.1" />
         <PackageReference Include="FastEndpoints" Version="8.1.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.11.2">


### PR DESCRIPTION
## Summary
- align FastEndpoints Swagger and Testing packages to 8.1.0
- collapse IdentityApi to a single AddFastEndpoints registration chain
- configure a shared FastEndpoints `api` route prefix and remove per-endpoint hard-coded `/api` route prefixes
- fix remove endpoint test request type drift and the impediment get-by-id unit test setup
- resolve Kiota and EF Core relational package warnings, plus the nullable response warning in list organizations
- add architecture checks to keep FastEndpoints package versions, global route prefix usage, and endpoint route-prefix conventions aligned

## Verification
- `dotnet restore cpnucleo.slnx`
- `dotnet build cpnucleo.slnx --no-restore`
- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore` — 35/35 passed
- `dotnet test tests/Security.Unit.Tests/Security.Unit.Tests.csproj --no-restore` — 11/11 passed
- `dotnet test tests/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj --no-restore` — 47 passed, 2 skipped

## Notes
- Root `MapGet("/")` routes were intentionally left as Minimal API routes.
- `dotnet test cpnucleo.slnx --no-restore` still requires a running local PostgreSQL on `127.0.0.1:5432`; this hosted lane has Docker CLI installed but no active Docker daemon, so integration tests fail here with connection refused when the database is unavailable.
- The earlier full-solution compile blocker from remove endpoint `Request` type drift is fixed.
- The earlier Kiota `NU1903` and EF Core relational version conflict warnings are fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FastEndpoints-related package dependencies from version 7.2.0 to 8.1.0 across the application and test projects.

* **Tests**
  * Added automated architecture tests to validate FastEndpoints dependency alignment and ensure consistent configuration across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->