### PR TITLE
Fix Hostinger WebClient healthcheck

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -22,7 +22,7 @@ x-common-healthcheck:
     timeout: 10s
     retries: 3
   x-healthcheck-webclient: &healthcheck-webclient
-    test: ["CMD-SHELL", "timeout 5 bash -c '</dev/tcp/127.0.0.1/5030'"]
+    test: ["CMD", "wget", "-qO-", "http://127.0.0.1:5030/healthz"]
     interval: 30s
     timeout: 10s
     retries: 3


### PR DESCRIPTION
## Summary
- replace the production WebClient compose healthcheck with the same wget-based check the nginx image supports
- remove the bash /dev/tcp dependency from the nginx-alpine WebClient container healthcheck

## Root cause
The Hostinger deployment was healthy except `webclient-cpnucleo`. `compose.prod.yaml` overrode the WebClient image healthcheck with `bash -c </dev/tcp/...`, but the runtime image is `nginx:1.27-alpine` and does not include bash. Docker therefore marked only the WebClient container unhealthy even though the app image starts.

## Verification
- inspected failed run 26346969786 deploy logs
- verified `compose.prod.yaml` now uses `wget` and no longer references bash/dev-tcp for WebClient
- `git diff --check`

Note: local Docker daemon is unavailable in this runner, so container runtime verification should come from CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved web client health monitoring by updating the health check mechanism for better reliability and accuracy in production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->