### PR TITLE
Polish WebClient login and theme

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -22,7 +22,7 @@ x-common-healthcheck:
     timeout: 10s
     retries: 3
   x-healthcheck-webclient: &healthcheck-webclient
-    test: ["CMD-SHELL", "timeout 5 bash -c '</dev/tcp/127.0.0.1/5030'"]
+    test: ["CMD", "wget", "-qO-", "http://127.0.0.1:5030/healthz"]
     interval: 30s
     timeout: 10s
     retries: 3

--- a/src/WebClient/src/components/auth-guard.tsx
+++ b/src/WebClient/src/components/auth-guard.tsx
@@ -1,7 +1,8 @@
 import { component$, Slot, useSignal, useVisibleTask$ } from '@builder.io/qwik';
 import { clearStoredToken, getStoredToken } from '~/lib/api/http-client';
+import { getLoginPath, getLoginRedirectTarget } from '~/lib/auth-navigation';
 
-const loginPath = '/login';
+const loginPath = getLoginPath();
 
 export const AuthGuard = component$(() => {
   const checked = useSignal(false);
@@ -12,9 +13,7 @@ export const AuthGuard = component$(() => {
     authenticated.value = Boolean(token);
     checked.value = true;
     if (!token) {
-      const current = `${window.location.pathname}${window.location.search}`;
-      const returnUrl = current && current !== '/' ? `?returnUrl=${encodeURIComponent(current)}` : '';
-      window.location.replace(`${loginPath}${returnUrl}`);
+      window.location.replace(getLoginRedirectTarget(window.location));
     }
   });
 

--- a/src/WebClient/src/components/theme-toggle.tsx
+++ b/src/WebClient/src/components/theme-toggle.tsx
@@ -1,0 +1,40 @@
+import { component$, useSignal, useVisibleTask$ } from '@builder.io/qwik';
+
+type Theme = 'light' | 'dark';
+
+const storageKey = 'cpnucleo-theme';
+
+const applyTheme = (theme: Theme) => {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+};
+
+export const ThemeToggle = component$(() => {
+  const theme = useSignal<Theme>('light');
+
+  useVisibleTask$(() => {
+    const stored = window.localStorage.getItem(storageKey);
+    const next = stored === 'dark' || stored === 'light'
+      ? stored
+      : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    theme.value = next;
+    applyTheme(next);
+  });
+
+  return (
+    <button
+      type="button"
+      class="inline-flex items-center gap-2 rounded-full border border-line bg-raised px-3 py-2 text-sm font-semibold text-ink shadow-sm transition hover:border-accent/40 hover:text-accent"
+      aria-label={`Switch to ${theme.value === 'dark' ? 'light' : 'dark'} mode`}
+      onClick$={() => {
+        const next: Theme = theme.value === 'dark' ? 'light' : 'dark';
+        theme.value = next;
+        window.localStorage.setItem(storageKey, next);
+        applyTheme(next);
+      }}
+    >
+      <span aria-hidden="true">{theme.value === 'dark' ? '☾' : '☀'}</span>
+      <span>{theme.value === 'dark' ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+});

--- a/src/WebClient/src/global.css
+++ b/src/WebClient/src/global.css
@@ -12,17 +12,51 @@
   --accent: 58% 0.16 225;
   --danger: 56% 0.18 25;
   --success: 55% 0.14 155;
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  --canvas: 12% 0.018 260;
+  --surface: 17% 0.02 260;
+  --raised: 22% 0.022 260;
+  --ink: 96% 0.006 250;
+  --muted: 72% 0.028 255;
+  --line: 31% 0.028 255;
+  --accent: 72% 0.15 260;
+  --danger: 68% 0.18 25;
+  --success: 70% 0.14 155;
+  color-scheme: dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --canvas: 12% 0.018 260;
+    --surface: 17% 0.02 260;
+    --raised: 22% 0.022 260;
+    --ink: 96% 0.006 250;
+    --muted: 72% 0.028 255;
+    --line: 31% 0.028 255;
+    --accent: 72% 0.15 260;
+    --danger: 68% 0.18 25;
+    --success: 70% 0.14 155;
+    color-scheme: dark;
+  }
 }
 
 * { box-sizing: border-box; }
 html { color-scheme: light; }
+html[data-theme='dark'] { color-scheme: dark; }
 body {
   margin: 0;
   min-height: 100vh;
-  background: oklch(var(--canvas));
+  background:
+    radial-gradient(circle at top left, oklch(var(--accent) / 0.08), transparent 34rem),
+    oklch(var(--canvas));
   color: oklch(var(--ink));
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-feature-settings: "cv01", "ss03";
 }
 a { color: inherit; text-decoration: none; }
 button, input, select, textarea { font: inherit; }
+input, select, textarea { color: oklch(var(--ink)); }
 :focus-visible { outline: 2px solid oklch(var(--accent)); outline-offset: 2px; }

--- a/src/WebClient/src/layouts/AppLayout.astro
+++ b/src/WebClient/src/layouts/AppLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../global.css';
 import { AuthStatus } from '../components/auth-guard';
+import { ThemeToggle } from '../components/theme-toggle';
 
 const groups = [
   { name: 'Work', items: [
@@ -8,7 +9,7 @@ const groups = [
   ] },
   { name: 'People', items: [['Users', '/users'], ['User assignments', '/user-assignments'], ['User projects', '/user-projects']] },
   { name: 'Configuration', items: [['Types', '/settings/types'], ['Relations', '/settings/relations'], ['Assignment types', '/assignment-types'], ['Impediments', '/impediments'], ['Assignment impediments', '/assignment-impediments']] },
-  { name: 'System', items: [['API health', '/api-health'], ['Login', '/login']] },
+  { name: 'System', items: [['API health', '/api-health']] },
 ] as const;
 
 const { path = '/' } = Astro.props;
@@ -21,12 +22,24 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>CPnucleo</title>
+    <script is:inline>
+      (() => {
+        try {
+          const stored = localStorage.getItem('cpnucleo-theme');
+          const theme = stored === 'dark' || stored === 'light'
+            ? stored
+            : matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          document.documentElement.dataset.theme = theme;
+          document.documentElement.style.colorScheme = theme;
+        } catch {}
+      })();
+    </script>
   </head>
   <body>
     <div class="min-h-screen bg-canvas text-ink">
       <aside class="fixed inset-y-0 left-0 z-40 hidden w-72 border-r border-line bg-surface px-5 py-6 lg:block">
         <a href="/" class="mb-8 flex items-center gap-3">
-          <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-ink text-sm font-bold text-white">CP</span>
+          <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-ink text-sm font-bold text-canvas">CP</span>
           <span><span class="block text-base font-semibold">CPnucleo</span><span class="block text-xs text-muted">Project management</span></span>
         </a>
         <nav class="mt-8 space-y-6">
@@ -35,7 +48,7 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
               <h2 class="px-3 text-xs font-semibold uppercase tracking-wide text-muted">{group.name}</h2>
               <div class="mt-2 space-y-1">
                 {group.items.map(([label, href]) => (
-                  <a href={href} class:list={["block rounded-lg px-3 py-2 text-sm font-medium transition", isActive(href) ? "bg-ink text-white shadow-sm" : "text-muted hover:bg-raised hover:text-ink"]}>{label}</a>
+                  <a href={href} class:list={["block rounded-lg px-3 py-2 text-sm font-medium transition", isActive(href) ? "bg-ink text-canvas shadow-sm" : "text-muted hover:bg-raised hover:text-ink"]}>{label}</a>
                 ))}
               </div>
             </section>
@@ -54,7 +67,7 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
                       <h2 class="px-3 text-xs font-semibold uppercase tracking-wide text-muted">{group.name}</h2>
                       <div class="mt-2 space-y-1">
                         {group.items.map(([label, href]) => (
-                          <a href={href} class:list={["block rounded-lg px-3 py-2 text-sm font-medium transition", isActive(href) ? "bg-ink text-white shadow-sm" : "text-muted hover:bg-raised hover:text-ink"]}>{label}</a>
+                          <a href={href} class:list={["block rounded-lg px-3 py-2 text-sm font-medium transition", isActive(href) ? "bg-ink text-canvas shadow-sm" : "text-muted hover:bg-raised hover:text-ink"]}>{label}</a>
                         ))}
                       </div>
                     </section>
@@ -67,7 +80,8 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
               <h1 class="text-lg font-semibold">Project operations</h1>
             </div>
             <div class="flex items-center gap-2 text-sm">
-              <span class="rounded-full border border-line bg-raised px-3 py-1 text-muted">Local-ready</span>
+              <ThemeToggle />
+              <span class="hidden rounded-full border border-line bg-raised px-3 py-1 text-muted sm:inline-flex">Local-ready</span>
               <AuthStatus />
             </div>
           </div>

--- a/src/WebClient/src/lib/auth-navigation.test.ts
+++ b/src/WebClient/src/lib/auth-navigation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getLoginPath, getLoginRedirectTarget, getPostLoginRedirectTarget } from './auth-navigation';
+
+describe('auth navigation', () => {
+  it('redirects protected pages to the trailing-slash login route without leaking the internal container port', () => {
+    const target = getLoginRedirectTarget({ pathname: '/', search: '', origin: 'https://cpnucleo.jonathanperis.tech:5030' });
+
+    expect(target).toBe('/login/');
+    expect(target).not.toContain('5030');
+    expect(target).not.toContain('cpnucleo.jonathanperis.tech');
+  });
+
+  it('keeps protected return urls relative', () => {
+    expect(getLoginRedirectTarget({ pathname: '/projects', search: '?page=2', origin: 'https://cpnucleo.jonathanperis.tech:5030' }))
+      .toBe('/login/?returnUrl=%2Fprojects%3Fpage%3D2');
+  });
+
+  it('rejects absolute and protocol-relative post-login return urls', () => {
+    expect(getPostLoginRedirectTarget('https://evil.test/projects')).toBe('/');
+    expect(getPostLoginRedirectTarget('//evil.test/projects')).toBe('/');
+    expect(getPostLoginRedirectTarget('/projects')).toBe('/projects');
+  });
+
+  it('uses the canonical standalone login path', () => {
+    expect(getLoginPath()).toBe('/login/');
+  });
+});

--- a/src/WebClient/src/lib/auth-navigation.ts
+++ b/src/WebClient/src/lib/auth-navigation.ts
@@ -1,0 +1,22 @@
+export const getLoginPath = () => '/login/';
+
+type LocationLike = Pick<Location, 'pathname' | 'search'> & { origin?: string };
+
+export const getLoginRedirectTarget = ({ pathname, search }: LocationLike): string => {
+  const loginPath = getLoginPath();
+  const current = `${pathname}${search}`;
+  const isLoginPage = pathname === '/login' || pathname === loginPath;
+  const returnUrl = current && current !== '/' && !isLoginPage
+    ? `?returnUrl=${encodeURIComponent(current)}`
+    : '';
+
+  return `${loginPath}${returnUrl}`;
+};
+
+export const getPostLoginRedirectTarget = (returnUrl: string | null): string => {
+  if (!returnUrl || !returnUrl.startsWith('/') || returnUrl.startsWith('//')) {
+    return '/';
+  }
+
+  return returnUrl;
+};

--- a/src/WebClient/src/pages/login.astro
+++ b/src/WebClient/src/pages/login.astro
@@ -1,8 +1,61 @@
 ---
-import AppLayout from '../layouts/AppLayout.astro';
+import '../global.css';
+import { ThemeToggle } from '../components/theme-toggle';
 import Page from '../routes/login/index';
 ---
 
-<AppLayout path="/login">
-  <Page />
-</AppLayout>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign in · CPnucleo</title>
+    <script is:inline>
+      (() => {
+        try {
+          const stored = localStorage.getItem('cpnucleo-theme');
+          const theme = stored === 'dark' || stored === 'light'
+            ? stored
+            : matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          document.documentElement.dataset.theme = theme;
+          document.documentElement.style.colorScheme = theme;
+        } catch {}
+      })();
+    </script>
+  </head>
+  <body>
+    <main class="min-h-screen overflow-hidden bg-canvas text-ink">
+      <div class="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,oklch(var(--accent)/0.14),transparent_34%),radial-gradient(circle_at_bottom_right,oklch(var(--success)/0.12),transparent_28%)]"></div>
+      <div class="mx-auto grid min-h-screen max-w-7xl grid-cols-1 px-6 py-6 lg:grid-cols-[1.05fr_0.95fr] lg:px-10">
+        <section class="flex flex-col justify-between py-4 lg:py-8">
+          <div class="flex items-center justify-between">
+            <a href="/" class="flex items-center gap-3">
+              <span class="flex h-11 w-11 items-center justify-center rounded-2xl bg-ink text-sm font-bold text-canvas shadow-soft">CP</span>
+              <span>
+                <span class="block text-base font-semibold">CPnucleo</span>
+                <span class="block text-xs text-muted">Operations workspace</span>
+              </span>
+            </a>
+            <ThemeToggle />
+          </div>
+
+          <div class="max-w-2xl py-12 lg:py-0">
+            <p class="mb-4 inline-flex rounded-full border border-line bg-surface px-3 py-1 text-sm font-semibold text-accent shadow-sm">Identity-first access</p>
+            <h1 class="text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">Sign in before entering the dashboard.</h1>
+            <p class="mt-5 max-w-xl text-base leading-7 text-muted sm:text-lg">A standalone login keeps the project dashboard private until IdentityApi issues a bearer token for WebApi operations.</p>
+            <div class="mt-8 grid max-w-xl gap-3 sm:grid-cols-3">
+              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">12</p><p class="mt-1 text-sm text-muted">CRUD surfaces</p></div>
+              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">JWT</p><p class="mt-1 text-sm text-muted">Session bearer</p></div>
+              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">REST</p><p class="mt-1 text-sm text-muted">WebApi access</p></div>
+            </div>
+          </div>
+
+          <p class="hidden text-sm text-muted lg:block">Protected dashboard · Light and dark mode ready</p>
+        </section>
+
+        <section class="flex items-center justify-center pb-8 lg:pb-0">
+          <Page />
+        </section>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/WebClient/src/routes/index.tsx
+++ b/src/WebClient/src/routes/index.tsx
@@ -13,21 +13,60 @@ export default component$(() => {
     counts.value = next;
   });
 
+  const featured = resourceMetadata.slice(0, 6);
+
   return (
     <div class="space-y-8">
-      <section class="rounded-2xl border border-line bg-surface p-6 shadow-soft">
-        <p class="text-sm font-medium text-accent">Astro + Qwik WebClient</p>
-        <h2 class="mt-2 text-3xl font-semibold tracking-tight">Run CPnucleo operations from one clean workspace.</h2>
-        <p class="mt-3 max-w-3xl text-sm leading-6 text-muted">Manage organizations, projects, assignments, workflows, people, appointments, and join records through the WebApi CRUD surface.</p>
-        <div class="mt-5 flex flex-wrap gap-2">
-          <a class="rounded-lg bg-ink px-4 py-2 text-sm font-semibold text-white" href="/projects">Open projects</a>
-          <a class="rounded-lg border border-line px-4 py-2 text-sm font-semibold" href="/api-health">Check API health</a>
+      <section class="overflow-hidden rounded-[2rem] border border-line bg-surface shadow-soft">
+        <div class="grid gap-6 p-6 lg:grid-cols-[1.15fr_0.85fr] lg:p-8">
+          <div>
+            <p class="inline-flex rounded-full border border-line bg-raised px-3 py-1 text-sm font-semibold text-accent">Astro + Qwik WebClient</p>
+            <h2 class="mt-5 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">Run CPnucleo operations from one polished workspace.</h2>
+            <p class="mt-4 max-w-2xl text-base leading-7 text-muted">Manage organizations, projects, assignments, workflows, people, appointments, and configuration records through a clean WebApi CRUD surface.</p>
+            <div class="mt-7 flex flex-wrap gap-3">
+              <a class="rounded-xl bg-ink px-5 py-3 text-sm font-semibold text-canvas shadow-soft transition hover:opacity-90" href="/projects">Open projects</a>
+              <a class="rounded-xl border border-line bg-raised px-5 py-3 text-sm font-semibold transition hover:border-accent/40 hover:text-accent" href="/api-health">Check API health</a>
+            </div>
+          </div>
+          <div class="rounded-[1.5rem] border border-line bg-raised p-5">
+            <div class="flex items-center justify-between border-b border-line pb-4">
+              <div>
+                <p class="text-sm font-semibold">Workspace pulse</p>
+                <p class="text-xs text-muted">Live counts after login</p>
+              </div>
+              <span class="rounded-full bg-success/10 px-3 py-1 text-xs font-semibold text-success">Online</span>
+            </div>
+            <div class="mt-4 grid gap-3">
+              {featured.slice(0, 4).map((resource) => (
+                <a href={resource.routePath} class="flex items-center justify-between rounded-xl border border-line bg-surface px-4 py-3 transition hover:border-accent/40">
+                  <span class="text-sm font-semibold">{resource.pluralLabel}</span>
+                  <span class="rounded-full bg-raised px-2.5 py-1 text-xs text-muted">{counts.value[resource.key] ?? '—'}</span>
+                </a>
+              ))}
+            </div>
+          </div>
         </div>
       </section>
+
       <section>
-        <h3 class="mb-3 text-lg font-semibold">Resource overview</h3>
-        <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {resourceMetadata.map((resource) => <a key={resource.key} href={resource.routePath} class="rounded-xl border border-line bg-surface p-4 shadow-sm hover:shadow-soft"><div class="flex items-center justify-between"><span class="font-semibold">{resource.pluralLabel}</span><span class="rounded-full bg-raised px-2 py-1 text-xs text-muted">{counts.value[resource.key] ?? '—'}</span></div><p class="mt-2 text-sm text-muted">{resource.description}</p></a>)}
+        <div class="mb-4 flex items-end justify-between gap-4">
+          <div>
+            <p class="text-sm font-semibold text-accent">Resources</p>
+            <h3 class="mt-1 text-2xl font-semibold tracking-tight">Operational modules</h3>
+          </div>
+          <span class="hidden text-sm text-muted sm:inline">Light by default · dark-ready</span>
+        </div>
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {resourceMetadata.map((resource) => (
+            <a key={resource.key} href={resource.routePath} class="group rounded-2xl border border-line bg-surface p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-accent/40 hover:shadow-soft">
+              <div class="flex items-start justify-between gap-3">
+                <span class="font-semibold">{resource.pluralLabel}</span>
+                <span class="rounded-full bg-raised px-2.5 py-1 text-xs text-muted">{counts.value[resource.key] ?? '—'}</span>
+              </div>
+              <p class="mt-3 text-sm leading-6 text-muted">{resource.description}</p>
+              <span class="mt-4 inline-flex text-sm font-semibold text-accent opacity-80 transition group-hover:opacity-100">Open module →</span>
+            </a>
+          ))}
         </div>
       </section>
     </div>

--- a/src/WebClient/src/routes/login/index.tsx
+++ b/src/WebClient/src/routes/login/index.tsx
@@ -1,5 +1,6 @@
 import { component$, useSignal } from '@builder.io/qwik';
 import { login } from '~/lib/api/identity-client';
+import { getPostLoginRedirectTarget } from '~/lib/auth-navigation';
 
 export default component$(() => {
   const loading = useSignal(false);
@@ -7,13 +8,13 @@ export default component$(() => {
   const success = useSignal(false);
 
   return (
-    <section class="mx-auto max-w-md rounded-2xl border border-line bg-surface p-6 shadow-soft">
-      <p class="text-sm font-medium text-accent">IdentityApi</p>
-      <h2 class="mt-1 text-2xl font-semibold">Sign in</h2>
-      <p class="mt-2 text-sm text-muted">Session tokens are stored in sessionStorage and sent as bearer tokens to WebApi requests.</p>
-      {error.value && <div role="alert" aria-live="assertive" aria-atomic="true" class="mt-4 rounded-lg border border-danger/25 bg-danger/5 px-3 py-2 text-sm text-danger">{error.value}</div>}
-      {success.value && <div role="status" aria-live="polite" aria-atomic="true" class="mt-4 rounded-lg border border-success/25 bg-success/5 px-3 py-2 text-sm text-success">Login successful. Continue to the dashboard.</div>}
-      <form class="mt-5 space-y-4" preventdefault:submit onSubmit$={async (event) => {
+    <section class="w-full max-w-md rounded-[2rem] border border-line bg-surface/95 p-6 shadow-soft backdrop-blur sm:p-8">
+      <p class="text-sm font-semibold text-accent">IdentityApi login</p>
+      <h2 class="mt-2 text-3xl font-semibold tracking-tight">Welcome back</h2>
+      <p class="mt-3 text-sm leading-6 text-muted">Enter your CPnucleo credentials to open the dashboard workspace.</p>
+      {error.value && <div role="alert" aria-live="assertive" aria-atomic="true" class="mt-5 rounded-xl border border-danger/25 bg-danger/5 px-4 py-3 text-sm text-danger">{error.value}</div>}
+      {success.value && <div role="status" aria-live="polite" aria-atomic="true" class="mt-5 rounded-xl border border-success/25 bg-success/5 px-4 py-3 text-sm text-success">Login successful. Opening the dashboard…</div>}
+      <form class="mt-6 space-y-5" preventdefault:submit onSubmit$={async (event) => {
         const form = event.currentTarget as HTMLFormElement;
         const data = new FormData(form);
         const loginName = String(data.get('login') ?? '');
@@ -26,16 +27,22 @@ export default component$(() => {
           form.reset();
           const params = new URLSearchParams(window.location.search);
           const returnUrl = params.get('returnUrl');
-          window.location.assign(returnUrl && returnUrl.startsWith('/') ? returnUrl : '/');
+          window.location.assign(getPostLoginRedirectTarget(returnUrl));
         }
         catch (err) { error.value = err instanceof Error ? err.message : 'Unable to log in.'; }
         finally { loading.value = false; }
       }}>
-        <label><span class="mb-1 block text-sm font-medium">Login</span><input name="login" autocomplete="username" class="w-full rounded-lg border border-line bg-raised px-3 py-2" /></label>
-        <label><span class="mb-1 block text-sm font-medium">Password</span><input name="password" type="password" autocomplete="current-password" class="w-full rounded-lg border border-line bg-raised px-3 py-2" /></label>
-        <button disabled={loading.value} class="w-full rounded-lg bg-ink px-4 py-2 font-semibold text-white disabled:opacity-50">{loading.value ? 'Signing in…' : 'Sign in'}</button>
+        <label class="block">
+          <span class="mb-2 block text-sm font-semibold">Login</span>
+          <input name="login" autocomplete="username" class="w-full rounded-xl border border-line bg-raised px-4 py-3 text-ink shadow-sm transition placeholder:text-muted focus:border-accent" placeholder="your.login" />
+        </label>
+        <label class="block">
+          <span class="mb-2 block text-sm font-semibold">Password</span>
+          <input name="password" type="password" autocomplete="current-password" class="w-full rounded-xl border border-line bg-raised px-4 py-3 text-ink shadow-sm transition placeholder:text-muted focus:border-accent" placeholder="••••••••" />
+        </label>
+        <button disabled={loading.value} class="w-full rounded-xl bg-ink px-4 py-3 font-semibold text-canvas shadow-soft transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50">{loading.value ? 'Signing in…' : 'Enter dashboard'}</button>
       </form>
-      <a class="mt-4 block text-center text-sm text-accent" href="/">Back to dashboard</a>
+      <p class="mt-5 text-center text-sm text-muted">You will be redirected to your requested dashboard page after login.</p>
     </section>
   );
 });


### PR DESCRIPTION
## Summary
- fix the unauthenticated redirect to use the canonical trailing-slash `/login/` path, avoiding nginx directory redirects that leak the internal `:5030` port
- move login to a standalone pre-dashboard page
- refresh the dashboard with a cleaner white workspace design
- add light/dark theme support with a persisted toggle

## Root cause
The auth guard redirected to `/login` without a trailing slash. In the static nginx container, `/login` maps to a generated directory, so nginx normalizes it to `/login/`. Behind Hostinger/Traefik this absolute directory redirect exposed the container listen port (`:5030`). Redirecting directly to `/login/` avoids the nginx normalization redirect and keeps navigation origin-relative.

## Verification
- `bun test src/lib/auth-navigation.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`
- local preview browser smoke: `/` redirects to `/login/`; no generated HTML contains `:5030`; standalone login renders in light and dark modes