### PR TITLE
Bring Cpnucleo docs design into WebClient

### DIFF
--- a/src/Infrastructure/Repositories/DapperRepository.cs
+++ b/src/Infrastructure/Repositories/DapperRepository.cs
@@ -109,9 +109,24 @@ public class DapperRepository<T>(NpgsqlConnection connection, NpgsqlTransaction?
 
     private static IEnumerable<PropertyInfo> GetProperties(bool excludeKey = false)
     {
-        return excludeKey 
-            ? CachedProperties.Value.Where(p => !p.Name.Equals("Id", StringComparison.OrdinalIgnoreCase))
-            : CachedProperties.Value;
+        var properties = CachedProperties.Value.Where(IsColumnProperty);
+
+        return excludeKey
+            ? properties.Where(p => !p.Name.Equals("Id", StringComparison.OrdinalIgnoreCase))
+            : properties;
+    }
+
+    private static bool IsColumnProperty(PropertyInfo property)
+    {
+        var type = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+
+        return type.IsPrimitive
+            || type.IsEnum
+            || type == typeof(string)
+            || type == typeof(Guid)
+            || type == typeof(DateTime)
+            || type == typeof(DateTimeOffset)
+            || type == typeof(decimal);
     }
 
     private static string GetColumns(bool excludeKey = false)

--- a/src/WebApi/Endpoints/Appointment/RemoveAppointment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Appointment/RemoveAppointment/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAppointm
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.Appointments!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.Appointments!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/Appointment/UpdateAppointment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Appointment/UpdateAppointment/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an appointment entity exists with Id: {AppointmentId}", request.Id);
-        var item = await dbContext.Appointments!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.Appointments!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/Assignment/CreateAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/CreateAssignment/Endpoint.cs
@@ -51,7 +51,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching assignment by Id: {AssignmentId}", newItem.Id);
-        var createdItem = await dbContext.Assignments!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.Assignments!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.Assignment = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/Assignment/RemoveAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/RemoveAssignment/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAssignme
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.Assignments!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.Assignments!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/Assignment/UpdateAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Assignment/UpdateAssignment/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an assignment entity exists with Id: {AssignmentId}", request.Id);
-        var item = await dbContext.Assignments!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.Assignments!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/AssignmentImpediment/CreateAssignmentImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/CreateAssignmentImpediment/Endpoint.cs
@@ -42,7 +42,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching assignmentImpediment by Id: {AssignmentImpedimentId}", newItem.Id);
-        var createdItem = await dbContext.AssignmentImpediments!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.AssignmentImpediments!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.AssignmentImpediment = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/AssignmentImpediment/RemoveAssignmentImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/RemoveAssignmentImpediment/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAssignme
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.AssignmentImpediments!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.AssignmentImpediments!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/AssignmentImpediment/UpdateAssignmentImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/UpdateAssignmentImpediment/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an assignmentImpediment entity exists with Id: {AssignmentImpedimentId}", request.Id);
-        var item = await dbContext.AssignmentImpediments!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.AssignmentImpediments!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/AssignmentType/CreateAssignmentType/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/CreateAssignmentType/Endpoint.cs
@@ -42,7 +42,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching assignmentType by Id: {AssignmentTypeId}", newItem.Id);
-        var createdItem = await dbContext.AssignmentTypes!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.AssignmentTypes!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.AssignmentType = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/AssignmentType/RemoveAssignmentType/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/RemoveAssignmentType/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveAssignme
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.AssignmentTypes!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.AssignmentTypes!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/AssignmentType/UpdateAssignmentType/Endpoint.cs
+++ b/src/WebApi/Endpoints/AssignmentType/UpdateAssignmentType/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an assignmentType entity exists with Id: {AssignmentTypeId}", request.Id);
-        var item = await dbContext.AssignmentTypes!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.AssignmentTypes!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/Impediment/CreateImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/CreateImpediment/Endpoint.cs
@@ -42,7 +42,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching impediment by Id: {ImpedimentId}", newItem.Id);
-        var createdItem = await dbContext.Impediments!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.Impediments!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.Impediment = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/Impediment/RemoveImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/RemoveImpediment/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveImpedime
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.Impediments!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.Impediments!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/Impediment/UpdateImpediment/Endpoint.cs
+++ b/src/WebApi/Endpoints/Impediment/UpdateImpediment/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an impediment entity exists with Id: {ImpedimentId}", request.Id);
-        var item = await dbContext.Impediments!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.Impediments!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/User/CreateUser/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/CreateUser/Endpoint.cs
@@ -43,7 +43,7 @@ public class Endpoint(IApplicationDbContext dbContext, IPasswordHasher passwordH
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching user by Id: {UserId}", newItem.Id);
-        var createdItem = await dbContext.Users!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.Users!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.User = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/User/RemoveUser/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/RemoveUser/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveUserRequ
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.Users!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.Users!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/User/UpdateUser/Endpoint.cs
+++ b/src/WebApi/Endpoints/User/UpdateUser/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext, IPasswordHasher passwordH
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an user entity exists with Id: {UserId}", request.Id);
-        var item = await dbContext.Users!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.Users!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/UserAssignment/CreateUserAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/CreateUserAssignment/Endpoint.cs
@@ -42,7 +42,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching userAssignment by Id: {UserAssignmentId}", newItem.Id);
-        var createdItem = await dbContext.UserAssignments!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.UserAssignments!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.UserAssignment = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/UserAssignment/RemoveUserAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/RemoveUserAssignment/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveUserAssi
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.UserAssignments!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.UserAssignments!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/UserAssignment/UpdateUserAssignment/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserAssignment/UpdateUserAssignment/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an userAssignment entity exists with Id: {UserAssignmentId}", request.Id);
-        var item = await dbContext.UserAssignments!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.UserAssignments!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/UserProject/CreateUserProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/CreateUserProject/Endpoint.cs
@@ -42,7 +42,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching userProject by Id: {UserProjectId}", newItem.Id);
-        var createdItem = await dbContext.UserProjects!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.UserProjects!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.UserProject = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/UserProject/RemoveUserProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/RemoveUserProject/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveUserProj
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.UserProjects!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.UserProjects!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/UserProject/UpdateUserProject/Endpoint.cs
+++ b/src/WebApi/Endpoints/UserProject/UpdateUserProject/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an userProject entity exists with Id: {UserProjectId}", request.Id);
-        var item = await dbContext.UserProjects!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.UserProjects!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebApi/Endpoints/Workflow/CreateWorkflow/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/CreateWorkflow/Endpoint.cs
@@ -42,7 +42,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         await dbContext.SaveChangesAsync(cancellationToken);
 
         Logger.LogInformation("Fetching workflow by Id: {WorkflowId}", newItem.Id);
-        var createdItem = await dbContext.Workflows!.FindAsync([newItem.Id, cancellationToken], cancellationToken: cancellationToken);
+        var createdItem = await dbContext.Workflows!.FindAsync([newItem.Id], cancellationToken: cancellationToken);
 
         Response.Workflow = createdItem!.MapToDto();
 

--- a/src/WebApi/Endpoints/Workflow/RemoveWorkflow/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/RemoveWorkflow/Endpoint.cs
@@ -25,7 +25,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<RemoveWorkflow
 
         foreach (var id in request.Ids)
         {
-            var item = await dbContext.Workflows!.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+            var item = await dbContext.Workflows!.FindAsync([id], cancellationToken: cancellationToken);
             if (item is null)
             {
                 await Send.NotFoundAsync(cancellation: cancellationToken);

--- a/src/WebApi/Endpoints/Workflow/UpdateWorkflow/Endpoint.cs
+++ b/src/WebApi/Endpoints/Workflow/UpdateWorkflow/Endpoint.cs
@@ -21,7 +21,7 @@ public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Respo
         Logger.LogInformation("Service started processing request.");
 
         Logger.LogInformation("Checking if an workflow entity exists with Id: {WorkflowId}", request.Id);
-        var item = await dbContext.Workflows!.FindAsync([request.Id, cancellationToken], cancellationToken: cancellationToken);
+        var item = await dbContext.Workflows!.FindAsync([request.Id], cancellationToken: cancellationToken);
 
         if (item is null)
         {

--- a/src/WebClient/src/components/auth-guard.tsx
+++ b/src/WebClient/src/components/auth-guard.tsx
@@ -20,9 +20,9 @@ export const AuthGuard = component$(() => {
   if (!checked.value) {
     return (
       <section class="rounded-2xl border border-line bg-surface p-6 shadow-soft" aria-live="polite">
-        <p class="text-sm font-medium text-accent">IdentityApi</p>
+        <p class="text-sm font-medium text-accent">Secure session</p>
         <h2 class="mt-2 text-2xl font-semibold">Checking your session…</h2>
-        <p class="mt-2 text-sm text-muted">Protected CPnucleo pages require a valid IdentityApi bearer token.</p>
+        <p class="mt-2 text-sm text-muted">Please sign in before opening the Cpnucleo workspace.</p>
       </section>
     );
   }
@@ -30,7 +30,7 @@ export const AuthGuard = component$(() => {
   if (!authenticated.value) {
     return (
       <section class="rounded-2xl border border-line bg-surface p-6 shadow-soft" aria-live="polite">
-        <p class="text-sm font-medium text-accent">IdentityApi</p>
+        <p class="text-sm font-medium text-accent">Secure session</p>
         <h2 class="mt-2 text-2xl font-semibold">Redirecting to sign in…</h2>
         <p class="mt-2 text-sm text-muted">Sign in to continue.</p>
       </section>

--- a/src/WebClient/src/global.css
+++ b/src/WebClient/src/global.css
@@ -50,8 +50,11 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(circle at top left, oklch(var(--accent) / 0.08), transparent 34rem),
+    radial-gradient(circle at top left, oklch(var(--accent) / 0.10), transparent 34rem),
+    linear-gradient(oklch(var(--line) / 0.22) 1px, transparent 1px),
+    linear-gradient(90deg, oklch(var(--line) / 0.18) 1px, transparent 1px),
     oklch(var(--canvas));
+  background-size: auto, 48px 48px, 48px 48px, auto;
   color: oklch(var(--ink));
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-feature-settings: "cv01", "ss03";

--- a/src/WebClient/src/layouts/AppLayout.astro
+++ b/src/WebClient/src/layouts/AppLayout.astro
@@ -4,12 +4,12 @@ import { AuthStatus } from '../components/auth-guard';
 import { ThemeToggle } from '../components/theme-toggle';
 
 const groups = [
-  { name: 'Work', items: [
-    ['Dashboard', '/'], ['Organizations', '/organizations'], ['Projects', '/projects'], ['Assignments', '/assignments'], ['Workflows', '/workflows'], ['Appointments', '/appointments'],
+  { name: 'Start', items: [
+    ['Home', '/'], ['Organizations', '/organizations'], ['Projects', '/projects'], ['Tasks', '/assignments'], ['Progress steps', '/workflows'], ['Calendar', '/appointments'],
   ] },
-  { name: 'People', items: [['Users', '/users'], ['User assignments', '/user-assignments'], ['User projects', '/user-projects']] },
-  { name: 'Configuration', items: [['Types', '/settings/types'], ['Relations', '/settings/relations'], ['Assignment types', '/assignment-types'], ['Impediments', '/impediments'], ['Assignment impediments', '/assignment-impediments']] },
-  { name: 'System', items: [['API health', '/api-health']] },
+  { name: 'People', items: [['Team members', '/users'], ['People on tasks', '/user-assignments'], ['People on projects', '/user-projects']] },
+  { name: 'Setup', items: [['Task types', '/assignment-types'], ['Blockers', '/impediments'], ['Task blockers', '/assignment-impediments']] },
+  { name: 'Status', items: [['Service health', '/api-health']] },
 ] as const;
 
 const { path = '/' } = Astro.props;
@@ -21,7 +21,7 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>CPnucleo</title>
+    <title>Cpnucleo</title>
     <script is:inline>
       (() => {
         try {
@@ -37,23 +37,32 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
   </head>
   <body>
     <div class="min-h-screen bg-canvas text-ink">
-      <aside class="fixed inset-y-0 left-0 z-40 hidden w-72 border-r border-line bg-surface px-5 py-6 lg:block">
-        <a href="/" class="mb-8 flex items-center gap-3">
-          <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-ink text-sm font-bold text-canvas">CP</span>
-          <span><span class="block text-base font-semibold">CPnucleo</span><span class="block text-xs text-muted">Project management</span></span>
+      <aside class="fixed inset-y-0 left-0 z-40 hidden w-72 border-r border-line bg-surface/95 px-5 py-6 shadow-soft lg:block">
+        <a href="/" class="mb-7 flex items-center gap-3">
+          <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-accent text-sm font-bold text-canvas shadow-soft">Cn</span>
+          <span>
+            <span class="block text-base font-semibold">Cpnucleo</span>
+            <span class="block text-xs text-muted">Project hub</span>
+          </span>
         </a>
-        <nav class="mt-8 space-y-6">
+        <label class="block rounded-2xl border border-line bg-raised px-3 py-2 text-sm text-muted">
+          Search pages or actions
+        </label>
+        <nav class="mt-7 space-y-6">
           {groups.map((group) => (
             <section>
-              <h2 class="px-3 text-xs font-semibold uppercase tracking-wide text-muted">{group.name}</h2>
+              <h2 class="px-3 text-xs font-semibold uppercase tracking-[0.18em] text-muted">{group.name}</h2>
               <div class="mt-2 space-y-1">
                 {group.items.map(([label, href]) => (
-                  <a href={href} class:list={["block rounded-lg px-3 py-2 text-sm font-medium transition", isActive(href) ? "bg-ink text-canvas shadow-sm" : "text-muted hover:bg-raised hover:text-ink"]}>{label}</a>
+                  <a href={href} aria-current={isActive(href) ? 'page' : undefined} class:list={["block rounded-xl border px-3 py-2 text-sm font-medium transition", isActive(href) ? "border-accent/40 bg-accent/10 text-accent shadow-sm" : "border-transparent text-muted hover:border-line hover:bg-raised hover:text-ink"]}>{label}</a>
                 ))}
               </div>
             </section>
           ))}
         </nav>
+        <div class="absolute inset-x-5 bottom-6 rounded-2xl border border-line bg-raised p-4 text-xs leading-5 text-muted">
+          Built as a clear place to review work, people, data, and releases without reading code first.
+        </div>
       </aside>
       <div class="lg:pl-72">
         <header class="sticky top-0 z-30 border-b border-line bg-surface/95 backdrop-blur">
@@ -64,10 +73,10 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
                 <nav class="space-y-5">
                   {groups.map((group) => (
                     <section>
-                      <h2 class="px-3 text-xs font-semibold uppercase tracking-wide text-muted">{group.name}</h2>
+                      <h2 class="px-3 text-xs font-semibold uppercase tracking-[0.18em] text-muted">{group.name}</h2>
                       <div class="mt-2 space-y-1">
                         {group.items.map(([label, href]) => (
-                          <a href={href} class:list={["block rounded-lg px-3 py-2 text-sm font-medium transition", isActive(href) ? "bg-ink text-canvas shadow-sm" : "text-muted hover:bg-raised hover:text-ink"]}>{label}</a>
+                          <a href={href} aria-current={isActive(href) ? 'page' : undefined} class:list={["block rounded-xl border px-3 py-2 text-sm font-medium transition", isActive(href) ? "border-accent/40 bg-accent/10 text-accent shadow-sm" : "border-transparent text-muted hover:border-line hover:bg-raised hover:text-ink"]}>{label}</a>
                         ))}
                       </div>
                     </section>
@@ -76,12 +85,12 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
               </div>
             </details>
             <div>
-              <p class="text-sm font-medium text-muted">CPnucleo WebClient</p>
-              <h1 class="text-lg font-semibold">Project operations</h1>
+              <p class="text-sm font-medium text-muted">Cpnucleo</p>
+              <h1 class="text-lg font-semibold">Application hub</h1>
             </div>
             <div class="flex items-center gap-2 text-sm">
               <ThemeToggle />
-              <span class="hidden rounded-full border border-line bg-raised px-3 py-1 text-muted sm:inline-flex">Local-ready</span>
+              <span class="hidden rounded-full border border-line bg-raised px-3 py-1 text-muted sm:inline-flex">Ready</span>
               <AuthStatus />
             </div>
           </div>

--- a/src/WebClient/src/lib/api/resource-metadata.ts
+++ b/src/WebClient/src/lib/api/resource-metadata.ts
@@ -17,57 +17,57 @@ const resource = (
 ): ResourceMetadata => ({ key, label, pluralLabel, listPath: `/${key}`, itemPath: `/${itemPath}`, routePath, description, displayField, fields: [...baseFields, ...fields] });
 
 export const resourceMetadata = [
-  resource('organizations', 'Organization', 'Organizations', 'organization', '/organizations', 'Companies and teams that own projects.', 'name', [
+  resource('organizations', 'Organization', 'Organizations', 'organization', '/organizations', 'Teams and groups that own projects.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'description', label: 'Description', type: 'textarea', table: true },
   ]),
-  resource('projects', 'Project', 'Projects', 'project', '/projects', 'Project records linked to an organization.', 'name', [
+  resource('projects', 'Project', 'Projects', 'project', '/projects', 'Project spaces connected to an organization.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'organizationId', label: 'Organization', type: 'guid', required: true, table: true, relation: 'organizations' },
   ]),
-  resource('assignments', 'Assignment', 'Assignments', 'assignment', '/assignments', 'Work items with schedule, budget, workflow, and people links.', 'name', [
+  resource('assignments', 'Task', 'Tasks', 'assignment', '/assignments', 'Work items with dates, hours, progress, and owner links.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'description', label: 'Description', type: 'textarea', table: true },
     { name: 'startDate', label: 'Start date', type: 'date', table: true },
     { name: 'endDate', label: 'End date', type: 'date', table: true },
     { name: 'amountHours', label: 'Hours', type: 'number', table: true },
     { name: 'projectId', label: 'Project', type: 'guid', required: true, table: true, relation: 'projects' },
-    { name: 'workflowId', label: 'Workflow', type: 'guid', table: true, relation: 'workflows' },
-    { name: 'userId', label: 'User', type: 'guid', table: true, relation: 'users' },
-    { name: 'assignmentTypeId', label: 'Assignment type', type: 'guid', table: true, relation: 'assignmentTypes' },
+    { name: 'workflowId', label: 'Progress step', type: 'guid', table: true, relation: 'workflows' },
+    { name: 'userId', label: 'Owner', type: 'guid', table: true, relation: 'users' },
+    { name: 'assignmentTypeId', label: 'Task type', type: 'guid', table: true, relation: 'assignmentTypes' },
   ]),
-  resource('assignmentTypes', 'Assignment type', 'Assignment types', 'assignmentType', '/assignment-types', 'Reusable categories for assignments.', 'name', [
+  resource('assignmentTypes', 'Task type', 'Task types', 'assignmentType', '/assignment-types', 'Reusable labels for different kinds of work.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
   ]),
-  resource('impediments', 'Impediment', 'Impediments', 'impediment', '/impediments', 'Known blockers that can affect work.', 'name', [
+  resource('impediments', 'Blocker', 'Blockers', 'impediment', '/impediments', 'Issues that may slow work down.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
   ]),
-  resource('assignmentImpediments', 'Assignment impediment', 'Assignment impediments', 'assignmentImpediment', '/assignment-impediments', 'Links blockers to assignments with context.', 'description', [
+  resource('assignmentImpediments', 'Task blocker', 'Task blockers', 'assignmentImpediment', '/assignment-impediments', 'Notes that connect blockers to a task.', 'description', [
     { name: 'description', label: 'Description', type: 'textarea', required: true, table: true },
-    { name: 'assignmentId', label: 'Assignment', type: 'guid', required: true, table: true, relation: 'assignments' },
-    { name: 'impedimentId', label: 'Impediment', type: 'guid', required: true, table: true, relation: 'impediments' },
+    { name: 'assignmentId', label: 'Task', type: 'guid', required: true, table: true, relation: 'assignments' },
+    { name: 'impedimentId', label: 'Blocker', type: 'guid', required: true, table: true, relation: 'impediments' },
   ]),
-  resource('appointments', 'Appointment', 'Appointments', 'appointment', '/appointments', 'Calendar entries for users on assignments.', 'description', [
+  resource('appointments', 'Calendar item', 'Calendar items', 'appointment', '/appointments', 'Scheduled moments connected to people and tasks.', 'description', [
     { name: 'description', label: 'Description', type: 'textarea', required: true, table: true },
     { name: 'keepDate', label: 'Date', type: 'datetime-local', required: true, table: true },
     { name: 'amountHours', label: 'Hours', type: 'number', table: true },
-    { name: 'assignmentId', label: 'Assignment', type: 'guid', required: true, table: true, relation: 'assignments' },
-    { name: 'userId', label: 'User', type: 'guid', required: true, table: true, relation: 'users' },
+    { name: 'assignmentId', label: 'Task', type: 'guid', required: true, table: true, relation: 'assignments' },
+    { name: 'userId', label: 'Person', type: 'guid', required: true, table: true, relation: 'users' },
   ]),
-  resource('workflows', 'Workflow', 'Workflows', 'workflow', '/workflows', 'Ordered workflow states for assignment progress.', 'name', [
+  resource('workflows', 'Progress step', 'Progress steps', 'workflow', '/workflows', 'Steps that show where a task is in the work path.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'order', label: 'Order', type: 'number', table: true },
   ]),
-  resource('users', 'User', 'Users', 'user', '/users', 'People that can own projects, assignments, and appointments.', 'name', [
+  resource('users', 'Team member', 'Team members', 'user', '/users', 'People who can own projects, tasks, and calendar items.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'login', label: 'Login', type: 'text', required: true, table: true },
   ]),
-  resource('userAssignments', 'User assignment', 'User assignments', 'userAssignment', '/user-assignments', 'Join records between users and assignments.', 'id', [
-    { name: 'userId', label: 'User', type: 'guid', required: true, table: true, relation: 'users' },
-    { name: 'assignmentId', label: 'Assignment', type: 'guid', required: true, table: true, relation: 'assignments' },
+  resource('userAssignments', 'Person on task', 'People on tasks', 'userAssignment', '/user-assignments', 'Connections between people and the tasks they help with.', 'id', [
+    { name: 'userId', label: 'Person', type: 'guid', required: true, table: true, relation: 'users' },
+    { name: 'assignmentId', label: 'Task', type: 'guid', required: true, table: true, relation: 'assignments' },
   ]),
-  resource('userProjects', 'User project', 'User projects', 'userProject', '/user-projects', 'Join records between users and projects.', 'id', [
-    { name: 'userId', label: 'User', type: 'guid', required: true, table: true, relation: 'users' },
+  resource('userProjects', 'Person on project', 'People on projects', 'userProject', '/user-projects', 'Connections between people and their project spaces.', 'id', [
+    { name: 'userId', label: 'Person', type: 'guid', required: true, table: true, relation: 'users' },
     { name: 'projectId', label: 'Project', type: 'guid', required: true, table: true, relation: 'projects' },
   ]),
 ] as const satisfies readonly ResourceMetadata[];

--- a/src/WebClient/src/pages/login.astro
+++ b/src/WebClient/src/pages/login.astro
@@ -8,7 +8,7 @@ import Page from '../routes/login/index';
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Sign in · CPnucleo</title>
+    <title>Sign in · Cpnucleo</title>
     <script is:inline>
       (() => {
         try {
@@ -29,9 +29,9 @@ import Page from '../routes/login/index';
         <section class="flex flex-col justify-between py-4 lg:py-8">
           <div class="flex items-center justify-between">
             <a href="/" class="flex items-center gap-3">
-              <span class="flex h-11 w-11 items-center justify-center rounded-2xl bg-ink text-sm font-bold text-canvas shadow-soft">CP</span>
+              <span class="flex h-11 w-11 items-center justify-center rounded-2xl bg-accent text-sm font-bold text-canvas shadow-soft">Cn</span>
               <span>
-                <span class="block text-base font-semibold">CPnucleo</span>
+                <span class="block text-base font-semibold">Cpnucleo</span>
                 <span class="block text-xs text-muted">Operations workspace</span>
               </span>
             </a>
@@ -41,11 +41,11 @@ import Page from '../routes/login/index';
           <div class="max-w-2xl py-12 lg:py-0">
             <p class="mb-4 inline-flex rounded-full border border-line bg-surface px-3 py-1 text-sm font-semibold text-accent shadow-sm">Identity-first access</p>
             <h1 class="text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">Sign in before entering the dashboard.</h1>
-            <p class="mt-5 max-w-xl text-base leading-7 text-muted sm:text-lg">A standalone login keeps the project dashboard private until IdentityApi issues a bearer token for WebApi operations.</p>
+            <p class="mt-5 max-w-xl text-base leading-7 text-muted sm:text-lg">A standalone login keeps the dashboard private. Sign in first, then choose what you want to review or update.</p>
             <div class="mt-8 grid max-w-xl gap-3 sm:grid-cols-3">
-              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">12</p><p class="mt-1 text-sm text-muted">CRUD surfaces</p></div>
-              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">JWT</p><p class="mt-1 text-sm text-muted">Session bearer</p></div>
-              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">REST</p><p class="mt-1 text-sm text-muted">WebApi access</p></div>
+              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">12</p><p class="mt-1 text-sm text-muted">Work areas</p></div>
+              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">Secure</p><p class="mt-1 text-sm text-muted">Private session</p></div>
+              <div class="rounded-2xl border border-line bg-surface/80 p-4 shadow-soft"><p class="text-2xl font-semibold">Live</p><p class="mt-1 text-sm text-muted">Service access</p></div>
             </div>
           </div>
 

--- a/src/WebClient/src/routes/api-health/index.tsx
+++ b/src/WebClient/src/routes/api-health/index.tsx
@@ -27,8 +27,8 @@ export default component$(() => {
   return (
     <section class="space-y-5">
       <div class="flex items-end justify-between gap-4">
-        <div><p class="text-sm font-medium text-accent">System</p><h2 class="text-3xl font-semibold">API health</h2><p class="mt-2 text-sm text-muted">Checks browser reachability for the configured WebApi and IdentityApi health endpoints.</p></div>
-        <button class="rounded-lg bg-ink px-4 py-2 text-sm font-semibold text-white" onClick$={run} disabled={loading.value}>{loading.value ? 'Checking…' : 'Run checks'}</button>
+        <div><p class="text-sm font-medium text-accent">Status</p><h2 class="text-3xl font-semibold">Service health</h2><p class="mt-2 text-sm text-muted">Checks whether the app services can be reached from your browser.</p></div>
+        <button class="rounded-lg bg-ink px-4 py-2 text-sm font-semibold text-canvas" onClick$={run} disabled={loading.value}>{loading.value ? 'Checking…' : 'Run checks'}</button>
       </div>
       <div class="grid gap-4 md:grid-cols-2" aria-live="polite" aria-busy={loading.value ? 'true' : 'false'}>
         {checks.value.length === 0 ? <p class="text-sm text-muted">Run checks to see current API status.</p> : checks.value.map((check) => <article key={check.name} class="rounded-xl border border-line bg-surface p-5 shadow-soft"><div class="flex items-center justify-between"><h3 class="font-semibold">{check.name}</h3><span class={["rounded-full px-2 py-1 text-xs font-medium", check.ok ? "bg-success/10 text-success" : "bg-danger/10 text-danger"]}>{check.ok ? 'Healthy' : 'Unavailable'}</span></div><p class="mt-2 break-all text-sm text-muted">{check.url}</p><p class="mt-3 text-sm">Status: {check.status}</p></article>)}

--- a/src/WebClient/src/routes/index.tsx
+++ b/src/WebClient/src/routes/index.tsx
@@ -2,6 +2,13 @@ import { component$, useSignal, useVisibleTask$ } from '@builder.io/qwik';
 import { resourceMetadata } from '~/lib/api/resource-metadata';
 import { webApiClient } from '~/lib/api/webapi-client';
 
+const shortcuts = [
+  ['Project overview', 'See what the app does, where the main work areas are, and where to begin.', '/projects'],
+  ['People and access', 'Review team members and the work they are connected to.', '/users'],
+  ['Data and storage', 'Browse the core records that keep projects, tasks, blockers, and calendar items connected.', '/organizations'],
+  ['Checks and status', 'Confirm the app services are reachable before you keep working.', '/api-health'],
+] as const;
+
 export default component$(() => {
   const counts = useSignal<Record<string, number>>({});
   useVisibleTask$(async () => {
@@ -18,21 +25,21 @@ export default component$(() => {
   return (
     <div class="space-y-8">
       <section class="overflow-hidden rounded-[2rem] border border-line bg-surface shadow-soft">
-        <div class="grid gap-6 p-6 lg:grid-cols-[1.15fr_0.85fr] lg:p-8">
+        <div class="grid gap-6 p-6 lg:grid-cols-[1.08fr_0.92fr] lg:p-8">
           <div>
-            <p class="inline-flex rounded-full border border-line bg-raised px-3 py-1 text-sm font-semibold text-accent">Astro + Qwik WebClient</p>
-            <h2 class="mt-5 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">Run CPnucleo operations from one polished workspace.</h2>
-            <p class="mt-4 max-w-2xl text-base leading-7 text-muted">Manage organizations, projects, assignments, workflows, people, appointments, and configuration records through a clean WebApi CRUD surface.</p>
+            <p class="inline-flex rounded-full border border-accent/30 bg-accent/10 px-3 py-1 text-sm font-semibold text-accent">Application hub</p>
+            <h2 class="mt-5 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">Choose where to start in Cpnucleo.</h2>
+            <p class="mt-4 max-w-2xl text-base leading-7 text-muted">Use this space to review projects, people, tasks, blockers, calendar items, and service status without digging through setup details first.</p>
             <div class="mt-7 flex flex-wrap gap-3">
               <a class="rounded-xl bg-ink px-5 py-3 text-sm font-semibold text-canvas shadow-soft transition hover:opacity-90" href="/projects">Open projects</a>
-              <a class="rounded-xl border border-line bg-raised px-5 py-3 text-sm font-semibold transition hover:border-accent/40 hover:text-accent" href="/api-health">Check API health</a>
+              <a class="rounded-xl border border-line bg-raised px-5 py-3 text-sm font-semibold transition hover:border-accent/40 hover:text-accent" href="/api-health">Check service status</a>
             </div>
           </div>
           <div class="rounded-[1.5rem] border border-line bg-raised p-5">
             <div class="flex items-center justify-between border-b border-line pb-4">
               <div>
                 <p class="text-sm font-semibold">Workspace pulse</p>
-                <p class="text-xs text-muted">Live counts after login</p>
+                <p class="text-xs text-muted">Live counts after sign in</p>
               </div>
               <span class="rounded-full bg-success/10 px-3 py-1 text-xs font-semibold text-success">Online</span>
             </div>
@@ -48,11 +55,27 @@ export default component$(() => {
         </div>
       </section>
 
+      <section class="rounded-[2rem] border border-line bg-surface p-5 shadow-soft lg:p-6">
+        <div class="mb-4">
+          <p class="text-sm font-semibold text-accent">Start</p>
+          <h3 class="mt-1 text-2xl font-semibold tracking-tight">Pick the path that matches your next step</h3>
+        </div>
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {shortcuts.map(([title, description, href]) => (
+            <a href={href} class="group rounded-2xl border border-line bg-raised p-5 transition hover:-translate-y-0.5 hover:border-accent/40 hover:shadow-soft">
+              <span class="font-semibold">{title}</span>
+              <p class="mt-3 text-sm leading-6 text-muted">{description}</p>
+              <span class="mt-4 inline-flex text-sm font-semibold text-accent opacity-80 transition group-hover:opacity-100">Open →</span>
+            </a>
+          ))}
+        </div>
+      </section>
+
       <section>
         <div class="mb-4 flex items-end justify-between gap-4">
           <div>
-            <p class="text-sm font-semibold text-accent">Resources</p>
-            <h3 class="mt-1 text-2xl font-semibold tracking-tight">Operational modules</h3>
+            <p class="text-sm font-semibold text-accent">Work areas</p>
+            <h3 class="mt-1 text-2xl font-semibold tracking-tight">Manage the records that power the app</h3>
           </div>
           <span class="hidden text-sm text-muted sm:inline">Light by default · dark-ready</span>
         </div>
@@ -64,7 +87,7 @@ export default component$(() => {
                 <span class="rounded-full bg-raised px-2.5 py-1 text-xs text-muted">{counts.value[resource.key] ?? '—'}</span>
               </div>
               <p class="mt-3 text-sm leading-6 text-muted">{resource.description}</p>
-              <span class="mt-4 inline-flex text-sm font-semibold text-accent opacity-80 transition group-hover:opacity-100">Open module →</span>
+              <span class="mt-4 inline-flex text-sm font-semibold text-accent opacity-80 transition group-hover:opacity-100">Open area →</span>
             </a>
           ))}
         </div>

--- a/src/WebClient/src/routes/login/index.tsx
+++ b/src/WebClient/src/routes/login/index.tsx
@@ -9,9 +9,9 @@ export default component$(() => {
 
   return (
     <section class="w-full max-w-md rounded-[2rem] border border-line bg-surface/95 p-6 shadow-soft backdrop-blur sm:p-8">
-      <p class="text-sm font-semibold text-accent">IdentityApi login</p>
+      <p class="text-sm font-semibold text-accent">Secure sign in</p>
       <h2 class="mt-2 text-3xl font-semibold tracking-tight">Welcome back</h2>
-      <p class="mt-3 text-sm leading-6 text-muted">Enter your CPnucleo credentials to open the dashboard workspace.</p>
+      <p class="mt-3 text-sm leading-6 text-muted">Enter your Cpnucleo credentials to open the dashboard workspace.</p>
       {error.value && <div role="alert" aria-live="assertive" aria-atomic="true" class="mt-5 rounded-xl border border-danger/25 bg-danger/5 px-4 py-3 text-sm text-danger">{error.value}</div>}
       {success.value && <div role="status" aria-live="polite" aria-atomic="true" class="mt-5 rounded-xl border border-success/25 bg-success/5 px-4 py-3 text-sm text-success">Login successful. Opening the dashboard…</div>}
       <form class="mt-6 space-y-5" preventdefault:submit onSubmit$={async (event) => {

--- a/tests/Architecture.Tests/DapperRepositorySourceTests.cs
+++ b/tests/Architecture.Tests/DapperRepositorySourceTests.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+
+namespace Architecture.Tests;
+
+public class DapperRepositorySourceTests
+{
+    [Fact]
+    public void DapperRepository_Should_Not_Treat_Navigation_Properties_As_Table_Columns()
+    {
+        var repositoryType = typeof(Infrastructure.Repositories.DapperRepository<Domain.Entities.Project>);
+        var getColumns = repositoryType.GetMethod("GetColumns", BindingFlags.NonPublic | BindingFlags.Static);
+
+        getColumns.Should().NotBeNull("the Dapper repository column selection helper should exist");
+        var columns = (string)getColumns!.Invoke(null, [false])!;
+
+        columns.Should().Contain("\"OrganizationId\"");
+        columns.Should().NotContain("\"Organization\"", "navigation objects are not database columns and break project seeding through the public API");
+    }
+}

--- a/tests/Architecture.Tests/WebApiEndpointSourceTests.cs
+++ b/tests/Architecture.Tests/WebApiEndpointSourceTests.cs
@@ -1,0 +1,40 @@
+namespace Architecture.Tests;
+
+public class WebApiEndpointSourceTests
+{
+    [Fact]
+    public void WebApi_Endpoints_Should_Not_Pass_CancellationToken_As_FindAsync_Key()
+    {
+        var repoRoot = LocateRepositoryRoot();
+        var endpointFiles = Directory.GetFiles(
+            Path.Combine(repoRoot, "src", "WebApi", "Endpoints"),
+            "*.cs",
+            SearchOption.AllDirectories);
+
+        var offenders = endpointFiles
+            .Select(path => new
+            {
+                Path = Path.GetRelativePath(repoRoot, path),
+                Text = File.ReadAllText(path)
+            })
+            .Where(file => file.Text.Contains("FindAsync([") && file.Text.Contains(", cancellationToken]"))
+            .Select(file => file.Path)
+            .OrderBy(path => path)
+            .ToArray();
+
+        offenders.Should().BeEmpty("EF Core FindAsync key arrays must contain only entity key values; the cancellation token belongs only in the named cancellationToken argument");
+    }
+
+    private static string LocateRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "cpnucleo.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the tests should run from inside the cpnucleo repository");
+        return directory!.FullName;
+    }
+}


### PR DESCRIPTION
## Summary
- adapt the WebClient shell and dashboard using the Cpnucleo GitHub Pages/docs visual language
- update visible product casing to Cpnucleo and make labels/copy less technical
- keep the light-first dashboard while preserving the dark-mode toggle

## Verification
- bun run typecheck
- bun test
- bun run build
- browser smoke/vision check for the standalone login page

## Production seed
- created a demo organization and demo login user through the live APIs
- verified the demo login returns a token