### PR TITLE
Fix demo login form submission

### DIFF
--- a/src/WebClient/src/routes/login/index.tsx
+++ b/src/WebClient/src/routes/login/index.tsx
@@ -1,6 +1,7 @@
 import { component$, useSignal } from '@builder.io/qwik';
 import { login } from '~/lib/api/identity-client';
 import { getPostLoginRedirectTarget } from '~/lib/auth-navigation';
+import { DEMO_LOGIN, DEMO_PASSWORD, getLoginFormElement } from './login-form';
 
 export default component$(() => {
   const loading = useSignal(false);
@@ -14,8 +15,8 @@ export default component$(() => {
       <p class="mt-3 text-sm leading-6 text-muted">Enter your Cpnucleo credentials to open the dashboard workspace.</p>
       {error.value && <div role="alert" aria-live="assertive" aria-atomic="true" class="mt-5 rounded-xl border border-danger/25 bg-danger/5 px-4 py-3 text-sm text-danger">{error.value}</div>}
       {success.value && <div role="status" aria-live="polite" aria-atomic="true" class="mt-5 rounded-xl border border-success/25 bg-success/5 px-4 py-3 text-sm text-success">Login successful. Opening the dashboard…</div>}
-      <form class="mt-6 space-y-5" preventdefault:submit onSubmit$={async (event) => {
-        const form = event.currentTarget as HTMLFormElement;
+      <form class="mt-6 space-y-5" preventdefault:submit onSubmit$={async (event, currentTarget) => {
+        const form = getLoginFormElement(event, currentTarget);
         const data = new FormData(form);
         const loginName = String(data.get('login') ?? '');
         const password = String(data.get('password') ?? '');
@@ -24,7 +25,6 @@ export default component$(() => {
         try {
           await login(loginName, password);
           success.value = true;
-          form.reset();
           const params = new URLSearchParams(window.location.search);
           const returnUrl = params.get('returnUrl');
           window.location.assign(getPostLoginRedirectTarget(returnUrl));
@@ -34,11 +34,11 @@ export default component$(() => {
       }}>
         <label class="block">
           <span class="mb-2 block text-sm font-semibold">Login</span>
-          <input name="login" autocomplete="username" class="w-full rounded-xl border border-line bg-raised px-4 py-3 text-ink shadow-sm transition placeholder:text-muted focus:border-accent" placeholder="your.login" />
+          <input name="login" autocomplete="username" class="w-full rounded-xl border border-line bg-raised px-4 py-3 text-ink shadow-sm transition placeholder:text-muted focus:border-accent" value={DEMO_LOGIN} />
         </label>
         <label class="block">
           <span class="mb-2 block text-sm font-semibold">Password</span>
-          <input name="password" type="password" autocomplete="current-password" class="w-full rounded-xl border border-line bg-raised px-4 py-3 text-ink shadow-sm transition placeholder:text-muted focus:border-accent" placeholder="••••••••" />
+          <input name="password" type="password" autocomplete="current-password" class="w-full rounded-xl border border-line bg-raised px-4 py-3 text-ink shadow-sm transition placeholder:text-muted focus:border-accent" value={DEMO_PASSWORD} />
         </label>
         <button disabled={loading.value} class="w-full rounded-xl bg-ink px-4 py-3 font-semibold text-canvas shadow-soft transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50">{loading.value ? 'Signing in…' : 'Enter dashboard'}</button>
       </form>

--- a/src/WebClient/src/routes/login/login-form.test.ts
+++ b/src/WebClient/src/routes/login/login-form.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { DEMO_LOGIN, DEMO_PASSWORD, getLoginFormElement } from './login-form';
+
+const formElement = { tagName: 'FORM' } as HTMLFormElement;
+const documentLikeTarget = { tagName: 'DOCUMENT' } as unknown as EventTarget;
+const buttonLikeTarget = { tagName: 'BUTTON' } as unknown as EventTarget;
+
+describe('login form helpers', () => {
+  it('uses Qwik delegated currentTarget argument instead of the document-level event currentTarget', () => {
+    const delegatedSubmitEvent = {
+      currentTarget: documentLikeTarget,
+      target: buttonLikeTarget,
+    } as SubmitEvent;
+
+    expect(getLoginFormElement(delegatedSubmitEvent, formElement)).toBe(formElement);
+  });
+
+  it('keeps demonstration credentials available for the prefilled login form', () => {
+    expect(DEMO_LOGIN).toBe('demo@cpnucleo.local');
+    expect(DEMO_PASSWORD).toBe('CpnucleoDemo2026!');
+  });
+});

--- a/src/WebClient/src/routes/login/login-form.ts
+++ b/src/WebClient/src/routes/login/login-form.ts
@@ -1,0 +1,16 @@
+export const DEMO_LOGIN = 'demo@cpnucleo.local';
+export const DEMO_PASSWORD = 'CpnucleoDemo2026!';
+
+const isHtmlFormElement = (target: unknown): target is HTMLFormElement => {
+  if (!target || typeof target !== 'object') return false;
+  if (typeof HTMLFormElement !== 'undefined' && target instanceof HTMLFormElement) return true;
+  return 'tagName' in target && String((target as { tagName?: unknown }).tagName).toUpperCase() === 'FORM';
+};
+
+export const getLoginFormElement = (event: Event, currentTarget?: EventTarget | null): HTMLFormElement => {
+  if (isHtmlFormElement(currentTarget)) return currentTarget;
+  if (isHtmlFormElement(event.currentTarget)) return event.currentTarget;
+  if (isHtmlFormElement(event.target)) return event.target;
+
+  throw new TypeError('Login form submit target is unavailable.');
+};


### PR DESCRIPTION
## Summary
- fix Qwik delegated submit handling on the login form so Enter dashboard actually posts credentials
- prefill the demo login and password for the demonstration system
- add regression coverage for the delegated form target and demo credentials

## Auth flow audit
- confirmed live IdentityApi accepts the demo credentials and returns a JWT
- confirmed WebClient stores only IdentityApi-issued JWTs in sessionStorage and sends Bearer tokens through the shared HTTP client
- confirmed WebApi and GrpcServer validate issuer, audience, signing key, and lifetime, with architecture tests covering protected endpoints/handlers
- confirmed unauthenticated live WebApi requests return 401; authenticated requests pass auth and proceed to endpoint validation/execution

## Verification
- bun test
- bun run typecheck
- bun run build
- local browser smoke: prefilled login form submits, stores an IdentityApi-issued token, and redirects to /
- dotnet build cpnucleo.slnx
- dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-build