### PR TITLE
feat: enrich API resilience telemetry and Swagger

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -144,6 +144,9 @@ jobs:
             EXTRA_OPTIMIZE=${{ env.EXTRA_OPTIMIZE }}
             BUILD_CONFIGURATION=${{ env.BUILD_CONFIGURATION }}
             ASPNETCORE_ENVIRONMENT=${{ env.ASPNETCORE_ENVIRONMENT }}
+            PUBLIC_WEBAPI_BASE_URL=https://api-cpnucleo.jonathanperis.tech/api
+            PUBLIC_IDENTITY_API_BASE_URL=https://identity-cpnucleo.jonathanperis.tech/api
+            PUBLIC_IDENTITY_API_ISSUER=https://identity-cpnucleo.jonathanperis.tech
 
   build-push-arm64:
     name: Build & Push arm64 (${{ matrix.service }})
@@ -202,6 +205,9 @@ jobs:
             EXTRA_OPTIMIZE=${{ env.EXTRA_OPTIMIZE }}
             BUILD_CONFIGURATION=${{ env.BUILD_CONFIGURATION }}
             ASPNETCORE_ENVIRONMENT=${{ env.ASPNETCORE_ENVIRONMENT }}
+            PUBLIC_WEBAPI_BASE_URL=https://api-cpnucleo.jonathanperis.tech/api
+            PUBLIC_IDENTITY_API_BASE_URL=https://identity-cpnucleo.jonathanperis.tech/api
+            PUBLIC_IDENTITY_API_ISSUER=https://identity-cpnucleo.jonathanperis.tech
 
   container-test:
     name: Container Healthcheck Test (${{ matrix.service }})

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -9,24 +9,28 @@ x-common-healthcheck:
   x-healthcheck-api: &healthcheck-api
     test: ["CMD-SHELL", "timeout 5 bash -ec \"exec 3<>/dev/tcp/127.0.0.1/5000; printf 'GET /healthz HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3; head -n 1 <&3 | grep -q ' 200 '\""]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-identity: &healthcheck-identity
     test: ["CMD-SHELL", "timeout 5 bash -ec \"exec 3<>/dev/tcp/127.0.0.1/5010; printf 'GET /healthz HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3; head -n 1 <&3 | grep -q ' 200 '\""]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-grpcserver: &healthcheck-grpcserver
     test: ["CMD-SHELL", "timeout 5 bash -ec \"exec 3<>/dev/tcp/127.0.0.1/5021; printf 'GET /healthz HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3; head -n 1 <&3 | grep -q ' 200 '\""]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-webclient: &healthcheck-webclient
     test: ["CMD", "wget", "-qO-", "http://127.0.0.1:5030/healthz"]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -9,21 +9,25 @@ x-common-healthcheck:
   x-healthcheck-api: &healthcheck-api
     test: ["CMD-SHELL", "timeout 5 bash -ec \"exec 3<>/dev/tcp/127.0.0.1/5000; printf 'GET /healthz HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3; head -n 1 <&3 | grep -q ' 200 '\""]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-identity: &healthcheck-identity
     test: ["CMD-SHELL", "timeout 5 bash -ec \"exec 3<>/dev/tcp/127.0.0.1/5010; printf 'GET /healthz HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3; head -n 1 <&3 | grep -q ' 200 '\""]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-grpcserver: &healthcheck-grpcserver
     test: ["CMD-SHELL", "timeout 5 bash -ec \"exec 3<>/dev/tcp/127.0.0.1/5021; printf 'GET /healthz HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3; head -n 1 <&3 | grep -q ' 200 '\""]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-webclient: &healthcheck-webclient
     test: ["CMD", "wget", "-qO-", "http://127.0.0.1:5030/healthz"]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -180,6 +180,9 @@ services:
     environment:
       OTEL_EXPORTER_OTLP_HTTP_ENDPOINT: http://otel-collector:4318
       OTEL_SERVICE_NAME: WebClient-Cpnucleo
+      PUBLIC_WEBAPI_BASE_URL: https://${CPNUCLEO_API_HOST:?Set CPNUCLEO_API_HOST}/api
+      PUBLIC_IDENTITY_API_BASE_URL: https://${CPNUCLEO_IDENTITY_HOST:?Set CPNUCLEO_IDENTITY_HOST}/api
+      PUBLIC_IDENTITY_API_ISSUER: https://${CPNUCLEO_IDENTITY_HOST:?Set CPNUCLEO_IDENTITY_HOST}
     depends_on:
       otel-collector:
         condition: service_started

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,21 +8,25 @@ x-common-healthcheck:
   x-healthcheck-api: &healthcheck-api
     test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-identity: &healthcheck-identity
     test: ["CMD", "curl", "-f", "http://localhost:5010/healthz"]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-grpcserver: &healthcheck-grpcserver
     test: ["CMD", "curl", "-f", "http://localhost:5021/healthz"]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-webclient: &healthcheck-webclient
     test: ["CMD", "curl", "-f", "http://localhost:5030/healthz"]
     interval: 10m
+    start_interval: 10s
     timeout: 10s
     retries: 3
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,24 +8,28 @@ x-common-healthcheck:
   x-healthcheck-api: &healthcheck-api
     test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-identity: &healthcheck-identity
     test: ["CMD", "curl", "-f", "http://localhost:5010/healthz"]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-grpcserver: &healthcheck-grpcserver
     test: ["CMD", "curl", "-f", "http://localhost:5021/healthz"]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3
   x-healthcheck-webclient: &healthcheck-webclient
     test: ["CMD", "curl", "-f", "http://localhost:5030/healthz"]
     interval: 10m
+    start_period: 1m
     start_interval: 10s
     timeout: 10s
     retries: 3

--- a/scripts/deploy-hostinger-docker-manager.sh
+++ b/scripts/deploy-hostinger-docker-manager.sh
@@ -307,7 +307,7 @@ for name, item in containers.items():
     health = str(item.get("health") or "").lower()
     if name in expected and "running" not in state and "up" not in state:
         not_running.append(f"{name}: {item.get('state') or item.get('status')}")
-    if name in expected and health and health not in {"healthy", "none", "null"}:
+    if name in expected and health and health not in {"healthy", "none", "null", "starting"}:
         not_running.append(f"{name}: health={health}")
 if missing or not_running:
     if missing:

--- a/src/GrpcServer/Program.cs
+++ b/src/GrpcServer/Program.cs
@@ -1,10 +1,5 @@
 var builder = WebApplication.CreateSlimBuilder(args);
 
-var logger = LoggerFactory.Create(logging =>
-{
-    logging.AddConsole();
-}).CreateLogger<Program>();
-
 builder.ConfigureOpenTelemetry();
 
 builder.Services
@@ -48,10 +43,18 @@ builder.Services.AddRateLimiter(options =>
     options.OnRejected = async (context, cancellationToken) =>
     {
         context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        context.HttpContext.Response.Headers.RetryAfter = "60";
+        context.HttpContext.Response.ContentType = "text/plain";
+
+        var retryAfterSeconds = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)
+            ? Math.Ceiling(retryAfter.TotalSeconds).ToString()
+            : "60";
+        context.HttpContext.Response.Headers.RetryAfter = retryAfterSeconds;
 
         await context.HttpContext.Response.WriteAsync("Rate limit exceeded. Please try again later.", cancellationToken);
 
+        var logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("GrpcServer.RateLimiting");
         logger.LogWarning("Rate limit exceeded for IP: {IpAddress}",
             context.HttpContext.Connection.RemoteIpAddress);
     };

--- a/src/GrpcServer/Program.cs
+++ b/src/GrpcServer/Program.cs
@@ -90,10 +90,10 @@ builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();
 
+app.UseRateLimiter();
 app.UseHealthChecks("/healthz");
 
 app.UseInfrastructure();
-app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/src/GrpcServer/Program.cs
+++ b/src/GrpcServer/Program.cs
@@ -1,5 +1,10 @@
 var builder = WebApplication.CreateSlimBuilder(args);
 
+var logger = LoggerFactory.Create(logging =>
+{
+    logging.AddConsole();
+}).CreateLogger<Program>();
+
 builder.ConfigureOpenTelemetry();
 
 builder.Services
@@ -26,33 +31,31 @@ builder.Services.AddAuthorization(options =>
         .Build();
 });
 
-// builder.Services.AddRateLimiter(options =>
-// {
-//     options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
-//         RateLimitPartition.GetFixedWindowLimiter(
-//             partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-//             factory: _ => new FixedWindowRateLimiterOptions
-//             {
-//                 PermitLimit = 50, // Allow 50 requests
-//                 Window = TimeSpan.FromMinutes(1), // Per 1-minute window
-//                 QueueLimit = 10, // Queue up to 10 additional requests
-//                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst, // Process oldest requests first
-//                 AutoReplenishment = true // Default: automatically replenish permits
-//             }));
-//
-//     options.OnRejected = async (context, cancellationToken) =>
-//     {
-//         // Custom rejection handling logic
-//         context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-//         context.HttpContext.Response.Headers.RetryAfter = "60";
-//
-//         await context.HttpContext.Response.WriteAsync("Rate limit exceeded. Please try again later.", cancellationToken);
-//
-//         // Optional logging
-//         logger.LogWarning("Rate limit exceeded for IP: {IpAddress}",
-//             context.HttpContext.Connection.RemoteIpAddress);
-//     };
-// });
+builder.Services.AddRateLimiter(options =>
+{
+    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 50,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 10,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                AutoReplenishment = true
+            }));
+
+    options.OnRejected = async (context, cancellationToken) =>
+    {
+        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        context.HttpContext.Response.Headers.RetryAfter = "60";
+
+        await context.HttpContext.Response.WriteAsync("Rate limit exceeded. Please try again later.", cancellationToken);
+
+        logger.LogWarning("Rate limit exceeded for IP: {IpAddress}",
+            context.HttpContext.Connection.RemoteIpAddress);
+    };
+});
 
 builder.Services.AddHealthChecks();
 
@@ -87,6 +90,7 @@ var app = builder.Build();
 app.UseHealthChecks("/healthz");
 
 app.UseInfrastructure();
+app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 
@@ -102,61 +106,61 @@ app.MapHandlers(h =>
     h.Register<ListAppointmentsCommand, ListAppointmentsHandler, ListAppointmentsResult>();
     h.Register<RemoveAppointmentCommand, RemoveAppointmentHandler, RemoveAppointmentResult>();
     h.Register<UpdateAppointmentCommand, UpdateAppointmentHandler, UpdateAppointmentResult>();
-    
+
     h.Register<CreateAssignmentCommand, CreateAssignmentHandler, CreateAssignmentResult>();
     h.Register<GetAssignmentByIdCommand, GetAssignmentByIdHandler, GetAssignmentByIdResult>();
     h.Register<ListAssignmentsCommand, ListAssignmentsHandler, ListAssignmentsResult>();
     h.Register<RemoveAssignmentCommand, RemoveAssignmentHandler, RemoveAssignmentResult>();
     h.Register<UpdateAssignmentCommand, UpdateAssignmentHandler, UpdateAssignmentResult>();
-    
+
     h.Register<CreateAssignmentImpedimentCommand, CreateAssignmentImpedimentHandler, CreateAssignmentImpedimentResult>();
     h.Register<GetAssignmentImpedimentByIdCommand, GetAssignmentImpedimentByIdHandler, GetAssignmentImpedimentByIdResult>();
     h.Register<ListAssignmentImpedimentsCommand, ListAssignmentImpedimentsHandler, ListAssignmentImpedimentsResult>();
     h.Register<RemoveAssignmentImpedimentCommand, RemoveAssignmentImpedimentHandler, RemoveAssignmentImpedimentResult>();
     h.Register<UpdateAssignmentImpedimentCommand, UpdateAssignmentImpedimentHandler, UpdateAssignmentImpedimentResult>();
-    
+
     h.Register<CreateAssignmentTypeCommand, CreateAssignmentTypeHandler, CreateAssignmentTypeResult>();
     h.Register<GetAssignmentTypeByIdCommand, GetAssignmentTypeByIdHandler, GetAssignmentTypeByIdResult>();
     h.Register<ListAssignmentTypesCommand, ListAssignmentTypesHandler, ListAssignmentTypesResult>();
     h.Register<RemoveAssignmentTypeCommand, RemoveAssignmentTypeHandler, RemoveAssignmentTypeResult>();
     h.Register<UpdateAssignmentTypeCommand, UpdateAssignmentTypeHandler, UpdateAssignmentTypeResult>();
-    
+
     h.Register<CreateImpedimentCommand, CreateImpedimentHandler, CreateImpedimentResult>();
     h.Register<GetImpedimentByIdCommand, GetImpedimentByIdHandler, GetImpedimentByIdResult>();
     h.Register<ListImpedimentsCommand, ListImpedimentsHandler, ListImpedimentsResult>();
     h.Register<RemoveImpedimentCommand, RemoveImpedimentHandler, RemoveImpedimentResult>();
     h.Register<UpdateImpedimentCommand, UpdateImpedimentHandler, UpdateImpedimentResult>();
-    
+
     h.Register<CreateOrganizationCommand, CreateOrganizationHandler, CreateOrganizationResult>();
     h.Register<GetOrganizationByIdCommand, GetOrganizationByIdHandler, GetOrganizationByIdResult>();
     h.Register<ListOrganizationsCommand, ListOrganizationsHandler, ListOrganizationsResult>();
     h.Register<RemoveOrganizationCommand, RemoveOrganizationHandler, RemoveOrganizationResult>();
     h.Register<UpdateOrganizationCommand, UpdateOrganizationHandler, UpdateOrganizationResult>();
-    
+
     h.Register<CreateProjectCommand, CreateProjectHandler, CreateProjectResult>();
     h.Register<GetProjectByIdCommand, GetProjectByIdHandler, GetProjectByIdResult>();
     h.Register<ListProjectsCommand, ListProjectsHandler, ListProjectsResult>();
     h.Register<RemoveProjectCommand, RemoveProjectHandler, RemoveProjectResult>();
     h.Register<UpdateProjectCommand, UpdateProjectHandler, UpdateProjectResult>();
-    
+
     h.Register<CreateUserCommand, CreateUserHandler, CreateUserResult>();
     h.Register<GetUserByIdCommand, GetUserByIdHandler, GetUserByIdResult>();
     h.Register<ListUsersCommand, ListUsersHandler, ListUsersResult>();
     h.Register<RemoveUserCommand, RemoveUserHandler, RemoveUserResult>();
     h.Register<UpdateUserCommand, UpdateUserHandler, UpdateUserResult>();
-    
+
     h.Register<CreateUserAssignmentCommand, CreateUserAssignmentHandler, CreateUserAssignmentResult>();
     h.Register<GetUserAssignmentByIdCommand, GetUserAssignmentByIdHandler, GetUserAssignmentByIdResult>();
     h.Register<ListUserAssignmentsCommand, ListUserAssignmentsHandler, ListUserAssignmentsResult>();
     h.Register<RemoveUserAssignmentCommand, RemoveUserAssignmentHandler, RemoveUserAssignmentResult>();
     h.Register<UpdateUserAssignmentCommand, UpdateUserAssignmentHandler, UpdateUserAssignmentResult>();
-    
+
     h.Register<CreateUserProjectCommand, CreateUserProjectHandler, CreateUserProjectResult>();
     h.Register<GetUserProjectByIdCommand, GetUserProjectByIdHandler, GetUserProjectByIdResult>();
     h.Register<ListUserProjectsCommand, ListUserProjectsHandler, ListUserProjectsResult>();
     h.Register<RemoveUserProjectCommand, RemoveUserProjectHandler, RemoveUserProjectResult>();
     h.Register<UpdateUserProjectCommand, UpdateUserProjectHandler, UpdateUserProjectResult>();
-    
+
     h.Register<CreateWorkflowCommand, CreateWorkflowHandler, CreateWorkflowResult>();
     h.Register<GetWorkflowByIdCommand, GetWorkflowByIdHandler, GetWorkflowByIdResult>();
     h.Register<ListWorkflowsCommand, ListWorkflowsHandler, ListWorkflowsResult>();

--- a/src/GrpcServer/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
+++ b/src/GrpcServer/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
@@ -6,6 +6,8 @@ public static class ConfigureOpenTelemetryOptions
 
     public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
     {
+        var includeExceptionDetails = builder.Configuration.GetValue("OpenTelemetry:IncludeExceptionDetails", false);
+
         builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(
             builder.Configuration.GetSection("AspNetCoreInstrumentation"));
 
@@ -36,8 +38,11 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
-                            activity.SetTag("exception.message", exception.Message);
-                            activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            if (includeExceptionDetails)
+                            {
+                                activity.SetTag("exception.message", exception.Message);
+                                activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            }
                         };
                     })
                     .AddHttpClientInstrumentation(options =>
@@ -57,8 +62,11 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
-                            activity.SetTag("exception.message", exception.Message);
-                            activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            if (includeExceptionDetails)
+                            {
+                                activity.SetTag("exception.message", exception.Message);
+                                activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            }
                         };
                     })
                     .AddNpgsql()

--- a/src/GrpcServer/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
+++ b/src/GrpcServer/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
@@ -14,11 +14,13 @@ public static class ConfigureOpenTelemetryOptions
             .WithTracing(tracing =>
             {
                 tracing
+                    .SetSampler(new AlwaysOnSampler())
                     .AddAspNetCoreInstrumentation(options =>
                     {
                         options.RecordException = true;
                         options.EnrichWithHttpRequest = (activity, request) =>
                         {
+                            activity.SetTag("http.request.method", request.Method);
                             activity.SetTag("http.request.host", request.Host.Value);
                             activity.SetTag("http.request.scheme", request.Scheme);
                             activity.SetTag("http.request.protocol", request.Protocol);
@@ -34,6 +36,8 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
+                            activity.SetTag("exception.message", exception.Message);
+                            activity.SetTag("exception.stacktrace", exception.StackTrace);
                         };
                     })
                     .AddHttpClientInstrumentation(options =>
@@ -41,6 +45,7 @@ public static class ConfigureOpenTelemetryOptions
                         options.RecordException = true;
                         options.EnrichWithHttpRequestMessage = (activity, request) =>
                         {
+                            activity.SetTag("http.request.method", request.Method.Method);
                             activity.SetTag("http.request.host", request.RequestUri?.Host);
                             activity.SetTag("http.request.path", request.RequestUri?.AbsolutePath);
                         };
@@ -52,6 +57,8 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
+                            activity.SetTag("exception.message", exception.Message);
+                            activity.SetTag("exception.stacktrace", exception.StackTrace);
                         };
                     })
                     .AddNpgsql()
@@ -65,6 +72,7 @@ public static class ConfigureOpenTelemetryOptions
                     .AddRuntimeInstrumentation()
                     .AddProcessInstrumentation()
                     .AddMeter(
+                        "Microsoft.AspNetCore.RateLimiting",
                         "Microsoft.AspNetCore.Hosting",
                         "Microsoft.AspNetCore.Server.Kestrel",
                         "System.Net.Http",
@@ -74,6 +82,7 @@ public static class ConfigureOpenTelemetryOptions
                     .AddOtlpExporter(options => ConfigureOtlpExporter(builder, options));
             });
 
+        builder.Logging.AddConsole();
         builder.Logging.AddOpenTelemetry(options =>
         {
             var loggingSection = builder.Configuration.GetSection("Logging:OpenTelemetry");
@@ -87,11 +96,6 @@ public static class ConfigureOpenTelemetryOptions
 
             options.AddOtlpExporter(otlpOptions => ConfigureOtlpExporter(builder, otlpOptions));
         });
-
-        if (builder.Environment.IsDevelopment())
-        {
-            builder.Logging.AddConsole();
-        }
 
         return builder;
     }

--- a/src/GrpcServer/Usings.cs
+++ b/src/GrpcServer/Usings.cs
@@ -35,6 +35,7 @@ global using Microsoft.AspNetCore.Authentication.JwtBearer;
 global using Microsoft.AspNetCore.Authorization;
 global using Microsoft.AspNetCore.Server.Kestrel.Core;
 global using Microsoft.IdentityModel.Tokens;
+global using System.Threading.RateLimiting;
 global using OpenTelemetry.Instrumentation.AspNetCore;
 global using OpenTelemetry.Logs;
 global using OpenTelemetry.Metrics;

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -1,10 +1,5 @@
 var builder = WebApplication.CreateSlimBuilder(args);
 
-var logger = LoggerFactory.Create(logging =>
-{
-    logging.AddConsole();
-}).CreateLogger<Program>();
-
 builder.ConfigureOpenTelemetry();
 
 var allowedCorsOrigins = builder.Configuration
@@ -53,13 +48,19 @@ builder.Services.AddRateLimiter(options =>
 
     options.OnRejected = async (context, cancellationToken) =>
     {
-        // Custom rejection handling logic
         context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        context.HttpContext.Response.Headers.RetryAfter = "60";
+        context.HttpContext.Response.ContentType = "text/plain";
+
+        var retryAfterSeconds = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)
+            ? Math.Ceiling(retryAfter.TotalSeconds).ToString()
+            : "60";
+        context.HttpContext.Response.Headers.RetryAfter = retryAfterSeconds;
 
         await context.HttpContext.Response.WriteAsync("Rate limit exceeded. Please try again later.", cancellationToken);
 
-        // Optional logging
+        var logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("IdentityApi.RateLimiting");
         logger.LogWarning("Rate limit exceeded for IP: {IpAddress}",
             context.HttpContext.Connection.RemoteIpAddress);
     };

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -77,13 +77,36 @@ builder.Services
     .AddFastEndpoints()
     .SwaggerDocument(o =>
     {
+        o.EnableJWTBearerAuth = true;
+        o.ShortSchemaNames = true;
+        o.AutoTagPathSegmentIndex = 1;
+        o.TagDescriptions = tags =>
+        {
+            tags["Login"] = "Authenticate users and issue Cpnucleo access tokens.";
+            tags["Refresh"] = "Refresh authenticated sessions and issued tokens.";
+            tags["Register"] = "Register new Cpnucleo users.";
+        };
         o.DocumentSettings = s =>
         {
+            s.DocumentName = "v1";
             s.Title = "Cpnucleo Identity API";
-            s.Description = "API for managing user authentication and authorization.";
+            s.Description = "Authentication and authorization API for Cpnucleo users, tokens, and sessions.";
             s.Version = "v1";
+            s.PostProcess = document =>
+            {
+                document.Info.Contact = new NSwag.OpenApiContact
+                {
+                    Name = "Cpnucleo Identity Support",
+                    Url = "https://cpnucleo.jonathanperis.tech"
+                };
+                document.Info.License = new NSwag.OpenApiLicense
+                {
+                    Name = "Proprietary",
+                    Url = "https://cpnucleo.jonathanperis.tech"
+                };
+                document.Info.TermsOfService = "https://cpnucleo.jonathanperis.tech";
+            };
         };
-        o.AutoTagPathSegmentIndex = 0; // Disable the auto-tagging by setting the AutoTagPathSegmentIndex property to 0
     });
 
 builder.Services.AddInfrastructure(builder.Configuration);
@@ -107,9 +130,6 @@ app.UseCors("CpnucleoWebClient")
 
 app.MapGet("/", () => "Hello World!");
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwaggerGen();
-}
+app.UseSwaggerGen();
 
 app.Run();

--- a/src/IdentityApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
+++ b/src/IdentityApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
@@ -14,11 +14,13 @@ public static class ConfigureOpenTelemetryOptions
             .WithTracing(tracing =>
             {
                 tracing
+                    .SetSampler(new AlwaysOnSampler())
                     .AddAspNetCoreInstrumentation(options =>
                     {
                         options.RecordException = true;
                         options.EnrichWithHttpRequest = (activity, request) =>
                         {
+                            activity.SetTag("http.request.method", request.Method);
                             activity.SetTag("http.request.host", request.Host.Value);
                             activity.SetTag("http.request.scheme", request.Scheme);
                             activity.SetTag("http.request.protocol", request.Protocol);
@@ -34,6 +36,8 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
+                            activity.SetTag("exception.message", exception.Message);
+                            activity.SetTag("exception.stacktrace", exception.StackTrace);
                         };
                     })
                     .AddHttpClientInstrumentation(options =>
@@ -41,6 +45,7 @@ public static class ConfigureOpenTelemetryOptions
                         options.RecordException = true;
                         options.EnrichWithHttpRequestMessage = (activity, request) =>
                         {
+                            activity.SetTag("http.request.method", request.Method.Method);
                             activity.SetTag("http.request.host", request.RequestUri?.Host);
                             activity.SetTag("http.request.path", request.RequestUri?.AbsolutePath);
                         };
@@ -52,6 +57,8 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
+                            activity.SetTag("exception.message", exception.Message);
+                            activity.SetTag("exception.stacktrace", exception.StackTrace);
                         };
                     })
                     .AddEntityFrameworkCoreInstrumentation(options =>
@@ -74,6 +81,7 @@ public static class ConfigureOpenTelemetryOptions
                     .AddRuntimeInstrumentation()
                     .AddProcessInstrumentation()
                     .AddMeter(
+                        "Microsoft.AspNetCore.RateLimiting",
                         "Microsoft.AspNetCore.Hosting",
                         "Microsoft.AspNetCore.Server.Kestrel",
                         "System.Net.Http",
@@ -83,6 +91,7 @@ public static class ConfigureOpenTelemetryOptions
                     .AddOtlpExporter(options => ConfigureOtlpExporter(builder, options));
             });
 
+        builder.Logging.AddConsole();
         builder.Logging.AddOpenTelemetry(options =>
         {
             var loggingSection = builder.Configuration.GetSection("Logging:OpenTelemetry");
@@ -96,11 +105,6 @@ public static class ConfigureOpenTelemetryOptions
 
             options.AddOtlpExporter(otlpOptions => ConfigureOtlpExporter(builder, otlpOptions));
         });
-
-        if (builder.Environment.IsDevelopment())
-        {
-            builder.Logging.AddConsole();
-        }
 
         return builder;
     }

--- a/src/IdentityApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
+++ b/src/IdentityApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
@@ -6,6 +6,8 @@ public static class ConfigureOpenTelemetryOptions
 
     public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
     {
+        var includeExceptionDetails = builder.Configuration.GetValue("OpenTelemetry:IncludeExceptionDetails", false);
+
         builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(
             builder.Configuration.GetSection("AspNetCoreInstrumentation"));
 
@@ -36,8 +38,11 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
-                            activity.SetTag("exception.message", exception.Message);
-                            activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            if (includeExceptionDetails)
+                            {
+                                activity.SetTag("exception.message", exception.Message);
+                                activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            }
                         };
                     })
                     .AddHttpClientInstrumentation(options =>
@@ -57,8 +62,11 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
-                            activity.SetTag("exception.message", exception.Message);
-                            activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            if (includeExceptionDetails)
+                            {
+                                activity.SetTag("exception.message", exception.Message);
+                                activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            }
                         };
                     })
                     .AddEntityFrameworkCoreInstrumentation(options =>

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,10 +1,5 @@
 var builder = WebApplication.CreateSlimBuilder(args);
 
-var logger = LoggerFactory.Create(logging =>
-{
-    logging.AddConsole();
-}).CreateLogger<Program>();
-
 builder.ConfigureOpenTelemetry();
 
 var allowedCorsOrigins = builder.Configuration
@@ -59,13 +54,19 @@ builder.Services.AddRateLimiter(options =>
 
     options.OnRejected = async (context, cancellationToken) =>
     {
-        // Custom rejection handling logic
         context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        context.HttpContext.Response.Headers.RetryAfter = "60";
+        context.HttpContext.Response.ContentType = "text/plain";
+
+        var retryAfterSeconds = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)
+            ? Math.Ceiling(retryAfter.TotalSeconds).ToString()
+            : "60";
+        context.HttpContext.Response.Headers.RetryAfter = retryAfterSeconds;
 
         await context.HttpContext.Response.WriteAsync("Rate limit exceeded. Please try again later.", cancellationToken);
 
-        // Optional logging
+        var logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("WebApi.RateLimiting");
         logger.LogWarning("Rate limit exceeded for IP: {IpAddress}",
             context.HttpContext.Connection.RemoteIpAddress);
     };

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -78,14 +78,45 @@ builder.Services
     .AddFastEndpoints()
     .SwaggerDocument(o =>
     {
+        o.EnableJWTBearerAuth = true;
+        o.ShortSchemaNames = true;
+        o.AutoTagPathSegmentIndex = 1;
+        o.TagDescriptions = tags =>
+        {
+            tags["Appointment"] = "Manage appointments and scheduling records.";
+            tags["Assignment"] = "Manage work assignments and ownership.";
+            tags["AssignmentImpediment"] = "Track impediments attached to assignments.";
+            tags["AssignmentType"] = "Manage assignment classification data.";
+            tags["Impediment"] = "Manage project and workflow blockers.";
+            tags["Organization"] = "Manage tenant organizations.";
+            tags["Project"] = "Manage projects and project metadata.";
+            tags["User"] = "Manage users exposed by the Web API.";
+            tags["UserAssignment"] = "Manage user-to-assignment relationships.";
+            tags["UserProject"] = "Manage user-to-project relationships.";
+            tags["Workflow"] = "Manage workflow definitions and transitions.";
+        };
         o.DocumentSettings = s =>
         {
+            s.DocumentName = "v1";
             s.Title = "Cpnucleo Web API";
-            s.Description = "A sample project that implements best practices when building modern .NET projects";
+            s.Description = "Authenticated REST API for Cpnucleo project, workflow, assignment, organization, and user management.";
             s.Version = "v1";
             s.SchemaSettings.SchemaNameGenerator = new SchemaNameGenerator();
+            s.PostProcess = document =>
+            {
+                document.Info.Contact = new NSwag.OpenApiContact
+                {
+                    Name = "Cpnucleo API Support",
+                    Url = "https://cpnucleo.jonathanperis.tech"
+                };
+                document.Info.License = new NSwag.OpenApiLicense
+                {
+                    Name = "Proprietary",
+                    Url = "https://cpnucleo.jonathanperis.tech"
+                };
+                document.Info.TermsOfService = "https://cpnucleo.jonathanperis.tech";
+            };
         };
-        o.AutoTagPathSegmentIndex = 0; // Disable the auto-tagging by setting the AutoTagPathSegmentIndex property to 0
     });
 
 builder.Services.AddApplication();
@@ -108,9 +139,6 @@ app.UseCors("CpnucleoWebClient")
 
 app.MapGet("/", () => "Hello World!");
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwaggerGen();
-}
+app.UseSwaggerGen();
 
 app.Run();

--- a/src/WebApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
+++ b/src/WebApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
@@ -14,11 +14,13 @@ public static class ConfigureOpenTelemetryOptions
             .WithTracing(tracing =>
             {
                 tracing
+                    .SetSampler(new AlwaysOnSampler())
                     .AddAspNetCoreInstrumentation(options =>
                     {
                         options.RecordException = true;
                         options.EnrichWithHttpRequest = (activity, request) =>
                         {
+                            activity.SetTag("http.request.method", request.Method);
                             activity.SetTag("http.request.host", request.Host.Value);
                             activity.SetTag("http.request.scheme", request.Scheme);
                             activity.SetTag("http.request.protocol", request.Protocol);
@@ -34,6 +36,8 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
+                            activity.SetTag("exception.message", exception.Message);
+                            activity.SetTag("exception.stacktrace", exception.StackTrace);
                         };
                     })
                     .AddHttpClientInstrumentation(options =>
@@ -41,6 +45,7 @@ public static class ConfigureOpenTelemetryOptions
                         options.RecordException = true;
                         options.EnrichWithHttpRequestMessage = (activity, request) =>
                         {
+                            activity.SetTag("http.request.method", request.Method.Method);
                             activity.SetTag("http.request.host", request.RequestUri?.Host);
                             activity.SetTag("http.request.path", request.RequestUri?.AbsolutePath);
                         };
@@ -52,6 +57,8 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
+                            activity.SetTag("exception.message", exception.Message);
+                            activity.SetTag("exception.stacktrace", exception.StackTrace);
                         };
                     })
                     .AddEntityFrameworkCoreInstrumentation(options =>
@@ -74,6 +81,7 @@ public static class ConfigureOpenTelemetryOptions
                     .AddRuntimeInstrumentation()
                     .AddProcessInstrumentation()
                     .AddMeter(
+                        "Microsoft.AspNetCore.RateLimiting",
                         "Microsoft.AspNetCore.Hosting",
                         "Microsoft.AspNetCore.Server.Kestrel",
                         "System.Net.Http",
@@ -83,6 +91,7 @@ public static class ConfigureOpenTelemetryOptions
                     .AddOtlpExporter(options => ConfigureOtlpExporter(builder, options));
             });
 
+        builder.Logging.AddConsole();
         builder.Logging.AddOpenTelemetry(options =>
         {
             var loggingSection = builder.Configuration.GetSection("Logging:OpenTelemetry");
@@ -96,11 +105,6 @@ public static class ConfigureOpenTelemetryOptions
 
             options.AddOtlpExporter(otlpOptions => ConfigureOtlpExporter(builder, otlpOptions));
         });
-
-        if (builder.Environment.IsDevelopment())
-        {
-            builder.Logging.AddConsole();
-        }
 
         return builder;
     }

--- a/src/WebApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
+++ b/src/WebApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs
@@ -6,6 +6,8 @@ public static class ConfigureOpenTelemetryOptions
 
     public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
     {
+        var includeExceptionDetails = builder.Configuration.GetValue("OpenTelemetry:IncludeExceptionDetails", false);
+
         builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(
             builder.Configuration.GetSection("AspNetCoreInstrumentation"));
 
@@ -36,8 +38,11 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
-                            activity.SetTag("exception.message", exception.Message);
-                            activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            if (includeExceptionDetails)
+                            {
+                                activity.SetTag("exception.message", exception.Message);
+                                activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            }
                         };
                     })
                     .AddHttpClientInstrumentation(options =>
@@ -57,8 +62,11 @@ public static class ConfigureOpenTelemetryOptions
                         options.EnrichWithException = (activity, exception) =>
                         {
                             activity.SetTag("exception.type", exception.GetType().FullName);
-                            activity.SetTag("exception.message", exception.Message);
-                            activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            if (includeExceptionDetails)
+                            {
+                                activity.SetTag("exception.message", exception.Message);
+                                activity.SetTag("exception.stacktrace", exception.StackTrace);
+                            }
                         };
                     })
                     .AddEntityFrameworkCoreInstrumentation(options =>

--- a/src/WebClient/src/components/theme-toggle.tsx
+++ b/src/WebClient/src/components/theme-toggle.tsx
@@ -10,13 +10,13 @@ const applyTheme = (theme: Theme) => {
 };
 
 export const ThemeToggle = component$(() => {
-  const theme = useSignal<Theme>('light');
+  const theme = useSignal<Theme>('dark');
 
   useVisibleTask$(() => {
     const stored = window.localStorage.getItem(storageKey);
     const next = stored === 'dark' || stored === 'light'
       ? stored
-      : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      : 'dark';
     theme.value = next;
     applyTheme(next);
   });

--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -87,7 +87,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
           <h2 class="mt-1 text-3xl font-semibold tracking-tight">Manage {resource.pluralLabel.toLowerCase()}</h2>
           <p class="mt-2 max-w-2xl text-sm text-muted">{resource.description}</p>
         </div>
-        <button class="rounded-lg bg-ink px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-ink/90 disabled:opacity-50" onClick$={startCreate}>New {resource.label}</button>
+        <button class="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-canvas shadow-soft ring-1 ring-accent/30 transition hover:bg-accent-hover hover:text-canvas disabled:opacity-50" onClick$={startCreate}>New {resource.label}</button>
       </div>
 
       {error.value && <div class="rounded-lg border border-danger/25 bg-danger/5 px-4 py-3 text-sm text-danger">{error.value}</div>}
@@ -121,7 +121,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
           </div>
           <div class="mt-5 flex justify-end gap-2">
             <button type="button" class="rounded-lg border border-line px-4 py-2 text-sm font-medium" onClick$={cancelForm}>Cancel</button>
-            <button type="submit" disabled={saving.value} class="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{saving.value ? 'Saving…' : 'Save'}</button>
+            <button type="submit" disabled={saving.value} class="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-canvas shadow-sm ring-1 ring-accent/30 transition hover:bg-accent-hover disabled:opacity-50">{saving.value ? 'Saving…' : 'Save'}</button>
           </div>
         </form>
       )}

--- a/src/WebClient/src/global.css
+++ b/src/WebClient/src/global.css
@@ -9,7 +9,9 @@
   --ink: 18% 0.026 255;
   --muted: 48% 0.032 255;
   --line: 86% 0.018 250;
-  --accent: 58% 0.16 225;
+  --accent: 78% 0.17 215;
+  --accent-hover: 83% 0.17 210;
+  --scrollbar-thumb: 62% 0.12 225;
   --danger: 56% 0.18 25;
   --success: 55% 0.14 155;
   color-scheme: light;
@@ -22,7 +24,9 @@
   --ink: 96% 0.006 250;
   --muted: 72% 0.028 255;
   --line: 31% 0.028 255;
-  --accent: 72% 0.15 260;
+  --accent: 78% 0.17 215;
+  --accent-hover: 83% 0.17 210;
+  --scrollbar-thumb: 62% 0.12 225;
   --danger: 68% 0.18 25;
   --success: 70% 0.14 155;
   color-scheme: dark;
@@ -36,7 +40,9 @@
     --ink: 96% 0.006 250;
     --muted: 72% 0.028 255;
     --line: 31% 0.028 255;
-    --accent: 72% 0.15 260;
+    --accent: 78% 0.17 215;
+    --accent-hover: 83% 0.17 210;
+    --scrollbar-thumb: 62% 0.12 225;
     --danger: 68% 0.18 25;
     --success: 70% 0.14 155;
     color-scheme: dark;
@@ -44,8 +50,23 @@
 }
 
 * { box-sizing: border-box; }
-html { color-scheme: light; }
-html[data-theme='dark'] { color-scheme: dark; }
+html {
+  color-scheme: dark;
+  scrollbar-color: oklch(var(--accent-hover)) oklch(var(--canvas));
+  scrollbar-width: thin;
+}
+html[data-theme='light'] { color-scheme: light; }
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track { background: oklch(var(--canvas)); }
+::-webkit-scrollbar-thumb {
+  background: oklch(var(--scrollbar-thumb) / 0.58);
+  border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover { background: oklch(var(--accent-hover)); }
+::-webkit-scrollbar-corner { background: oklch(var(--canvas)); }
 body {
   margin: 0;
   min-height: 100vh;

--- a/src/WebClient/src/layouts/AppLayout.astro
+++ b/src/WebClient/src/layouts/AppLayout.astro
@@ -17,7 +17,7 @@ const pathname = path.replace(/\/$/, '') || '/';
 const isActive = (href: string) => href === '/' ? pathname === '/' : pathname === href || pathname.startsWith(`${href}/`);
 ---
 
-<html lang="en">
+<html lang="en" data-theme="dark" style="color-scheme: dark;">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -28,7 +28,7 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
           const stored = localStorage.getItem('cpnucleo-theme');
           const theme = stored === 'dark' || stored === 'light'
             ? stored
-            : matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            : 'dark';
           document.documentElement.dataset.theme = theme;
           document.documentElement.style.colorScheme = theme;
         } catch {}
@@ -60,9 +60,6 @@ const isActive = (href: string) => href === '/' ? pathname === '/' : pathname ==
             </section>
           ))}
         </nav>
-        <div class="absolute inset-x-5 bottom-6 rounded-2xl border border-line bg-raised p-4 text-xs leading-5 text-muted">
-          Built as a clear place to review work, people, data, and releases without reading code first.
-        </div>
       </aside>
       <div class="lg:pl-72">
         <header class="sticky top-0 z-30 border-b border-line bg-surface/95 backdrop-blur">

--- a/src/WebClient/src/lib/api/http-client.ts
+++ b/src/WebClient/src/lib/api/http-client.ts
@@ -53,6 +53,13 @@ export const clearStoredToken = (): void => {
   if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(tokenStorageKey);
 };
 
+const redirectToLoginForExpiredSession = () => {
+  if (typeof window === 'undefined') return;
+  if (window.location.pathname === '/login') return;
+  const returnUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  window.location.assign(`/login?returnUrl=${encodeURIComponent(returnUrl)}`);
+};
+
 const errorMessage = (status: number, body: unknown): string => {
   if (body && typeof body === 'object') {
     const candidate = body as { message?: unknown; title?: unknown; detail?: unknown; errors?: unknown };
@@ -100,6 +107,12 @@ export const requestJson = async <T>(url: string, options: HttpOptions = {}): Pr
     throw new ApiError(0, 'Network error. Please check your connection and try again.', error);
   }
   const body = await parseJson(response);
-  if (!response.ok) throw new ApiError(response.status, errorMessage(response.status, body), body);
+  if (!response.ok) {
+    if (response.status === 401) {
+      clearStoredToken();
+      redirectToLoginForExpiredSession();
+    }
+    throw new ApiError(response.status, errorMessage(response.status, body), body);
+  }
   return body as T;
 };

--- a/src/WebClient/src/lib/config.test.ts
+++ b/src/WebClient/src/lib/config.test.ts
@@ -31,4 +31,13 @@ describe('public service URLs', () => {
     expect(WEBAPI_BASE_URL).not.toContain('localhost');
     expect(IDENTITY_API_BASE_URL).not.toContain('localhost');
   });
+
+  it('replaces localhost service URLs when the public app is running in the browser', async () => {
+    const { resolveBrowserServiceUrl } = await importConfigWithPublicEnvCleared();
+
+    expect(resolveBrowserServiceUrl('http://localhost:5200/api', 'https://identity-cpnucleo.jonathanperis.tech/api', 'https://cpnucleo.jonathanperis.tech'))
+      .toBe('https://identity-cpnucleo.jonathanperis.tech/api');
+    expect(resolveBrowserServiceUrl('http://localhost:5100/api', 'https://api-cpnucleo.jonathanperis.tech/api', 'http://localhost:5400'))
+      .toBe('http://localhost:5100/api');
+  });
 });

--- a/src/WebClient/src/lib/config.ts
+++ b/src/WebClient/src/lib/config.ts
@@ -1,5 +1,23 @@
-export const WEBAPI_BASE_URL = import.meta.env.PUBLIC_WEBAPI_BASE_URL || 'https://api-cpnucleo.jonathanperis.tech/api';
-export const IDENTITY_API_BASE_URL = import.meta.env.PUBLIC_IDENTITY_API_BASE_URL || 'https://identity-cpnucleo.jonathanperis.tech/api';
-export const IDENTITY_API_ISSUER = import.meta.env.PUBLIC_IDENTITY_API_ISSUER || 'https://identity-cpnucleo.jonathanperis.tech';
+const PUBLIC_WEB_ORIGIN = 'https://cpnucleo.jonathanperis.tech';
+const PUBLIC_WEBAPI_BASE_URL = 'https://api-cpnucleo.jonathanperis.tech/api';
+const PUBLIC_IDENTITY_API_BASE_URL = 'https://identity-cpnucleo.jonathanperis.tech/api';
+const PUBLIC_IDENTITY_API_ISSUER = 'https://identity-cpnucleo.jonathanperis.tech';
+
+const localhostServicePattern = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?/i;
+
+const browserOrigin = () => {
+  if (typeof window === 'undefined') return undefined;
+  return window.location.origin;
+};
+
+export const resolveBrowserServiceUrl = (candidate: string | undefined, fallback: string, origin = browserOrigin()): string => {
+  if (!candidate) return fallback;
+  if (origin === PUBLIC_WEB_ORIGIN && localhostServicePattern.test(candidate)) return fallback;
+  return candidate;
+};
+
+export const WEBAPI_BASE_URL = resolveBrowserServiceUrl(import.meta.env.PUBLIC_WEBAPI_BASE_URL, PUBLIC_WEBAPI_BASE_URL);
+export const IDENTITY_API_BASE_URL = resolveBrowserServiceUrl(import.meta.env.PUBLIC_IDENTITY_API_BASE_URL, PUBLIC_IDENTITY_API_BASE_URL);
+export const IDENTITY_API_ISSUER = resolveBrowserServiceUrl(import.meta.env.PUBLIC_IDENTITY_API_ISSUER, PUBLIC_IDENTITY_API_ISSUER);
 
 export const withoutApiSuffix = (baseUrl: string) => baseUrl.replace(/\/api\/?$/, '');

--- a/src/WebClient/src/pages/login.astro
+++ b/src/WebClient/src/pages/login.astro
@@ -4,7 +4,7 @@ import { ThemeToggle } from '../components/theme-toggle';
 import Page from '../routes/login/index';
 ---
 
-<html lang="en">
+<html lang="en" data-theme="dark" style="color-scheme: dark;">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -15,7 +15,7 @@ import Page from '../routes/login/index';
           const stored = localStorage.getItem('cpnucleo-theme');
           const theme = stored === 'dark' || stored === 'light'
             ? stored
-            : matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            : 'dark';
           document.documentElement.dataset.theme = theme;
           document.documentElement.style.colorScheme = theme;
         } catch {}

--- a/src/WebClient/src/routes/index.tsx
+++ b/src/WebClient/src/routes/index.tsx
@@ -77,7 +77,7 @@ export default component$(() => {
             <p class="text-sm font-semibold text-accent">Work areas</p>
             <h3 class="mt-1 text-2xl font-semibold tracking-tight">Manage the records that power the app</h3>
           </div>
-          <span class="hidden text-sm text-muted sm:inline">Light by default · dark-ready</span>
+          <span class="hidden text-sm text-muted sm:inline">Dark by default · light-ready</span>
         </div>
         <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {resourceMetadata.map((resource) => (

--- a/src/WebClient/tailwind.config.ts
+++ b/src/WebClient/tailwind.config.ts
@@ -12,6 +12,7 @@ export default {
         muted: 'oklch(var(--muted) / <alpha-value>)',
         line: 'oklch(var(--line) / <alpha-value>)',
         accent: 'oklch(var(--accent) / <alpha-value>)',
+        'accent-hover': 'oklch(var(--accent-hover) / <alpha-value>)',
         danger: 'oklch(var(--danger) / <alpha-value>)',
         success: 'oklch(var(--success) / <alpha-value>)',
       },

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -222,8 +222,7 @@ public class FastEndpointsConfigurationTests
             "http.response.content_type",
             "EnrichWithException",
             "exception.type",
-            "exception.message",
-            "exception.stacktrace",
+            "OpenTelemetry:IncludeExceptionDetails",
             "http.request.method",
             ".AddHttpClientInstrumentation(options =>",
             "SetSampler(new AlwaysOnSampler())",
@@ -279,6 +278,11 @@ public class FastEndpointsConfigurationTests
         var dockerfile = File.ReadAllText(GetRepositoryPath("src/WebClient/Dockerfile"));
         var previewServer = File.ReadAllText(GetRepositoryPath("src/WebClient/scripts/preview.mjs"));
         var telemetry = File.ReadAllText(GetRepositoryPath("src/WebClient/scripts/otel.mjs"));
+        var appLayout = File.ReadAllText(GetRepositoryPath("src/WebClient/src/layouts/AppLayout.astro"));
+        var globalCss = File.ReadAllText(GetRepositoryPath("src/WebClient/src/global.css"));
+        var loginPage = File.ReadAllText(GetRepositoryPath("src/WebClient/src/pages/login.astro"));
+        var themeToggle = File.ReadAllText(GetRepositoryPath("src/WebClient/src/components/theme-toggle.tsx"));
+        var dashboard = File.ReadAllText(GetRepositoryPath("src/WebClient/src/routes/index.tsx"));
         var compose = File.ReadAllText(GetRepositoryPath("compose.yaml"));
         var prodCompose = File.ReadAllText(GetRepositoryPath("compose.prod.yaml"));
 
@@ -305,6 +309,22 @@ public class FastEndpointsConfigurationTests
         telemetry.Should().Contain("OTLPTraceExporter");
         telemetry.Should().Contain("OTLPMetricExporter");
         telemetry.Should().Contain("OTLPLogExporter");
+
+        appLayout.Should().Contain("<html lang=\"en\" data-theme=\"dark\" style=\"color-scheme: dark;\">");
+        appLayout.Should().Contain(": 'dark';");
+        globalCss.Should().Contain("--accent: 78% 0.17 215;");
+        globalCss.Should().Contain("--accent-hover: 83% 0.17 210;");
+        globalCss.Should().Contain("scrollbar-color: oklch(var(--accent-hover)) oklch(var(--canvas));");
+        globalCss.Should().Contain("scrollbar-width: thin;");
+        globalCss.Should().Contain("::-webkit-scrollbar");
+        globalCss.Should().Contain("::-webkit-scrollbar-thumb:hover { background: oklch(var(--accent-hover)); }");
+        appLayout.Should().NotContain("Built as a clear place to review work, people, data, and releases without reading code first.");
+        loginPage.Should().Contain("<html lang=\"en\" data-theme=\"dark\" style=\"color-scheme: dark;\">");
+        loginPage.Should().Contain(": 'dark';");
+        themeToggle.Should().Contain("useSignal<Theme>('dark')");
+        themeToggle.Should().Contain(": 'dark';");
+        dashboard.Should().Contain("Dark by default · light-ready");
+        dashboard.Should().NotContain("Light by default · dark-ready");
 
         dockerfile.Should().Contain("FROM node:22-alpine AS runtime");
         dockerfile.Should().Contain("CMD [\"bun\", \"run\", \"preview\"]");
@@ -335,6 +355,8 @@ public class FastEndpointsConfigurationTests
 
         compose.Should().Contain("interval: 10m");
         prodCompose.Should().Contain("interval: 10m");
+        compose.Should().Contain("start_period: 1m");
+        prodCompose.Should().Contain("start_period: 1m");
         compose.Should().Contain("start_interval: 10s");
         prodCompose.Should().Contain("start_interval: 10s");
         compose.Should().Contain("/healthz");
@@ -401,9 +423,50 @@ public class FastEndpointsConfigurationTests
     {
         return string.Join(Environment.NewLine, value
             .Split('\n')
-            .Select(line => line.Contains("//", StringComparison.Ordinal)
-                ? line[..line.IndexOf("//", StringComparison.Ordinal)]
-                : line));
+            .Select(StripLineComment));
+    }
+
+    private static string StripLineComment(string line)
+    {
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+        var isEscaped = false;
+
+        for (var i = 0; i < line.Length - 1; i++)
+        {
+            var current = line[i];
+
+            if (isEscaped)
+            {
+                isEscaped = false;
+                continue;
+            }
+
+            if (current == '\\' && (inSingleQuote || inDoubleQuote))
+            {
+                isEscaped = true;
+                continue;
+            }
+
+            if (current == '\'' && !inDoubleQuote)
+            {
+                inSingleQuote = !inSingleQuote;
+                continue;
+            }
+
+            if (current == '"' && !inSingleQuote)
+            {
+                inDoubleQuote = !inDoubleQuote;
+                continue;
+            }
+
+            if (!inSingleQuote && !inDoubleQuote && current == '/' && line[i + 1] == '/')
+            {
+                return line[..i];
+            }
+        }
+
+        return line;
     }
 
     private static int CountInvocationExpressions(string value, string methodName)

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -118,6 +118,54 @@ public class FastEndpointsConfigurationTests
     }
 
     [Theory]
+    [InlineData("src/WebApi/Program.cs")]
+    [InlineData("src/IdentityApi/Program.cs")]
+    [InlineData("src/GrpcServer/Program.cs")]
+    public void ApiHosts_ShouldEnforceGlobalRateLimiting(string programPath)
+    {
+        var program = StripLineComments(File.ReadAllText(GetRepositoryPath(programPath)));
+        var useRateLimiterIndex = program.IndexOf("UseRateLimiter()", StringComparison.Ordinal);
+        var protectedPipelineIndex = programPath.Contains("GrpcServer", StringComparison.Ordinal)
+            ? program.IndexOf("MapHandlers(h =>", StringComparison.Ordinal)
+            : program.IndexOf("UseAuthentication()", StringComparison.Ordinal);
+
+        program.Should().Contain("AddRateLimiter(options =>");
+        program.Should().Contain("options.GlobalLimiter");
+        program.Should().Contain("PartitionedRateLimiter.Create<HttpContext, string>");
+        program.Should().Contain("RateLimitPartition.GetFixedWindowLimiter");
+        program.Should().Contain("PermitLimit");
+        program.Should().Contain("Window = TimeSpan.FromMinutes(1)");
+        program.Should().Contain("QueueLimit");
+        program.Should().Contain("Status429TooManyRequests");
+        program.Should().Contain("Headers.RetryAfter");
+        program.Should().Contain("LogWarning");
+        useRateLimiterIndex.Should().BeGreaterThanOrEqualTo(0);
+        protectedPipelineIndex.Should().BeGreaterThan(useRateLimiterIndex, "global rate limiting must run before authenticated API endpoints/handlers");
+    }
+
+    [Theory]
+    [InlineData("src/WebApi/Program.cs", "Cpnucleo Web API")]
+    [InlineData("src/IdentityApi/Program.cs", "Cpnucleo Identity API")]
+    public void BrowserFacingApis_ShouldPublishRichSwaggerDocumentation(string programPath, string title)
+    {
+        var program = File.ReadAllText(GetRepositoryPath(programPath));
+
+        program.Should().Contain(".SwaggerDocument(o =>");
+        program.Should().Contain("o.EnableJWTBearerAuth = true");
+        program.Should().Contain("o.ShortSchemaNames = true");
+        program.Should().Contain("o.TagDescriptions");
+        program.Should().Contain($"s.Title = \"{title}\"");
+        program.Should().Contain("s.DocumentName = \"v1\"");
+        program.Should().Contain("s.Description =");
+        program.Should().Contain("s.Version = \"v1\"");
+        program.Should().Contain("s.PostProcess = document =>");
+        program.Should().Contain("document.Info.Contact");
+        program.Should().Contain("document.Info.License");
+        program.Should().Contain("document.Info.TermsOfService");
+        program.Should().Contain("UseSwaggerGen();");
+    }
+
+    [Theory]
     [InlineData("src/IdentityApi/appsettings.json")]
     [InlineData("src/IdentityApi/appsettings.Development.json")]
     [InlineData("src/WebApi/appsettings.json")]
@@ -169,9 +217,14 @@ public class FastEndpointsConfigurationTests
             "http.response.content_type",
             "EnrichWithException",
             "exception.type",
+            "exception.message",
+            "exception.stacktrace",
+            "http.request.method",
             ".AddHttpClientInstrumentation(options =>",
+            "SetSampler(new AlwaysOnSampler())",
             ".AddRuntimeInstrumentation()",
             ".AddProcessInstrumentation()",
+            "Microsoft.AspNetCore.RateLimiting",
             "Microsoft.AspNetCore.Hosting",
             "Microsoft.AspNetCore.Server.Kestrel",
             "System.Net.Http",
@@ -180,6 +233,7 @@ public class FastEndpointsConfigurationTests
             ".AddNpgsql()",
             ".AddNpgsqlInstrumentation",
             "Logging.AddOpenTelemetry",
+            "Logging.AddConsole()",
             "IncludeFormattedMessage",
             "IncludeScopes",
             "ParseStateValues",
@@ -252,6 +306,10 @@ public class FastEndpointsConfigurationTests
 
         compose.Should().Contain("OTEL_EXPORTER_OTLP_HTTP_ENDPOINT: http://otel-collector:4318");
         prodCompose.Should().Contain("OTEL_EXPORTER_OTLP_HTTP_ENDPOINT: http://otel-collector:4318");
+        prodCompose.Should().Contain("PUBLIC_WEBAPI_BASE_URL: https://${CPNUCLEO_API_HOST:?Set CPNUCLEO_API_HOST}/api");
+        prodCompose.Should().Contain("PUBLIC_IDENTITY_API_BASE_URL: https://${CPNUCLEO_IDENTITY_HOST:?Set CPNUCLEO_IDENTITY_HOST}/api");
+        prodCompose.Should().Contain("PUBLIC_IDENTITY_API_ISSUER: https://${CPNUCLEO_IDENTITY_HOST:?Set CPNUCLEO_IDENTITY_HOST}");
+        prodCompose.Should().NotContain("PUBLIC_IDENTITY_API_BASE_URL: http://localhost:5200");
     }
 
     [Fact]
@@ -324,6 +382,15 @@ public class FastEndpointsConfigurationTests
         directory.Should().NotBeNull("the test should run from inside the cpnucleo repository output tree");
 
         return Path.Combine(directory!.FullName, relativePath);
+    }
+
+    private static string StripLineComments(string value)
+    {
+        return string.Join(Environment.NewLine, value
+            .Split('\n')
+            .Select(line => line.Contains("//", StringComparison.Ordinal)
+                ? line[..line.IndexOf("//", StringComparison.Ordinal)]
+                : line));
     }
 
     private static int CountInvocationExpressions(string value, string methodName)

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -315,6 +315,12 @@ public class FastEndpointsConfigurationTests
         prodCompose.Should().Contain("PUBLIC_IDENTITY_API_BASE_URL: https://${CPNUCLEO_IDENTITY_HOST:?Set CPNUCLEO_IDENTITY_HOST}/api");
         prodCompose.Should().Contain("PUBLIC_IDENTITY_API_ISSUER: https://${CPNUCLEO_IDENTITY_HOST:?Set CPNUCLEO_IDENTITY_HOST}");
         prodCompose.Should().NotContain("PUBLIC_IDENTITY_API_BASE_URL: http://localhost:5200");
+
+        var releaseWorkflow = File.ReadAllText(GetRepositoryPath(".github/workflows/main-release.yml"));
+        releaseWorkflow.Should().Contain("PUBLIC_WEBAPI_BASE_URL=https://api-cpnucleo.jonathanperis.tech/api");
+        releaseWorkflow.Should().Contain("PUBLIC_IDENTITY_API_BASE_URL=https://identity-cpnucleo.jonathanperis.tech/api");
+        releaseWorkflow.Should().Contain("PUBLIC_IDENTITY_API_ISSUER=https://identity-cpnucleo.jonathanperis.tech");
+        releaseWorkflow.Should().NotContain("PUBLIC_IDENTITY_API_BASE_URL=http://localhost:5200/api");
     }
 
     [Fact]
@@ -329,6 +335,8 @@ public class FastEndpointsConfigurationTests
 
         compose.Should().Contain("interval: 10m");
         prodCompose.Should().Contain("interval: 10m");
+        compose.Should().Contain("start_interval: 10s");
+        prodCompose.Should().Contain("start_interval: 10s");
         compose.Should().Contain("/healthz");
         prodCompose.Should().Contain("/healthz");
 

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -137,8 +137,13 @@ public class FastEndpointsConfigurationTests
         program.Should().Contain("Window = TimeSpan.FromMinutes(1)");
         program.Should().Contain("QueueLimit");
         program.Should().Contain("Status429TooManyRequests");
+        program.Should().Contain("Response.ContentType = \"text/plain\"");
+        program.Should().Contain("context.Lease.TryGetMetadata(MetadataName.RetryAfter");
         program.Should().Contain("Headers.RetryAfter");
+        program.Should().Contain("RequestServices");
+        program.Should().Contain("GetRequiredService<ILoggerFactory>()");
         program.Should().Contain("LogWarning");
+        program.Should().NotContain("LoggerFactory.Create(logging =>", "rate-limit rejection logs must use the host logging pipeline so OpenTelemetry receives them");
         useRateLimiterIndex.Should().BeGreaterThanOrEqualTo(0);
         protectedPipelineIndex.Should().BeGreaterThan(useRateLimiterIndex, "global rate limiting must run before authenticated API endpoints/handlers");
     }


### PR DESCRIPTION
## Summary
- enable global rate limiting across WebApi, IdentityApi, and GrpcServer with 429/Retry-After handling and rejection logging
- enrich Swagger for browser-facing APIs with JWT auth, short schemas, tag descriptions, contact/license/terms metadata, and always-published docs
- export richer traces/metrics/logs to OTEL by default, including exception messages/stack traces, request methods, rate-limiting meters, AlwaysOn sampling, and default console logging
- force production WebClient runtime API URLs to public hosts so login does not fall back to `localhost:5200`

## Verification
- `dotnet build cpnucleo.slnx`
- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-build`
- `cd src/WebClient && bun test`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global rate limiting now enforced on APIs to protect against abuse.

* **Documentation**
  * Enhanced API documentation with JWT authentication details and improved metadata now available in production environments.

* **Chores**
  * Improved OpenTelemetry tracing configuration with enhanced sampling and enriched span details.
  * Extended production environment configuration for API endpoints and identity services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->