### PR TITLE
fix: allow FastEndpoints list responses to instantiate

### DIFF
--- a/src/WebApi/Endpoints/Appointment/ListAppointments/Models.cs
+++ b/src/WebApi/Endpoints/Appointment/ListAppointments/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of appointments.
     /// </summary>
-    public required PaginatedResult<AppointmentDto?> Result { get; set; }
+    public PaginatedResult<AppointmentDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/Assignment/ListAssignments/Models.cs
+++ b/src/WebApi/Endpoints/Assignment/ListAssignments/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of assignments.
     /// </summary>
-    public required PaginatedResult<AssignmentDto?> Result { get; set; }
+    public PaginatedResult<AssignmentDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/AssignmentImpediment/ListAssignmentImpediments/Models.cs
+++ b/src/WebApi/Endpoints/AssignmentImpediment/ListAssignmentImpediments/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of assignmentImpediments.
     /// </summary>
-    public required PaginatedResult<AssignmentImpedimentDto?> Result { get; set; }
+    public PaginatedResult<AssignmentImpedimentDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/AssignmentType/ListAssignmentTypes/Models.cs
+++ b/src/WebApi/Endpoints/AssignmentType/ListAssignmentTypes/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of assignmentTypes.
     /// </summary>
-    public required PaginatedResult<AssignmentTypeDto?> Result { get; set; }
+    public PaginatedResult<AssignmentTypeDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/Impediment/ListImpediments/Models.cs
+++ b/src/WebApi/Endpoints/Impediment/ListImpediments/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of impediments.
     /// </summary>
-    public required PaginatedResult<ImpedimentDto?> Result { get; set; }
+    public PaginatedResult<ImpedimentDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/Project/ListProjects/Models.cs
+++ b/src/WebApi/Endpoints/Project/ListProjects/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of projects.
     /// </summary>
-    public required PaginatedResult<ProjectDto?> Result { get; set; }
+    public PaginatedResult<ProjectDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/User/ListUsers/Models.cs
+++ b/src/WebApi/Endpoints/User/ListUsers/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of users.
     /// </summary>
-    public required PaginatedResult<UserDto?> Result { get; set; }
+    public PaginatedResult<UserDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/UserAssignment/ListUserAssignments/Models.cs
+++ b/src/WebApi/Endpoints/UserAssignment/ListUserAssignments/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of userAssignments.
     /// </summary>
-    public required PaginatedResult<UserAssignmentDto?> Result { get; set; }
+    public PaginatedResult<UserAssignmentDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/UserProject/ListUserProjects/Models.cs
+++ b/src/WebApi/Endpoints/UserProject/ListUserProjects/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of userProjects.
     /// </summary>
-    public required PaginatedResult<UserProjectDto?> Result { get; set; }
+    public PaginatedResult<UserProjectDto?> Result { get; set; } = null!;
 }

--- a/src/WebApi/Endpoints/Workflow/ListWorkflows/Models.cs
+++ b/src/WebApi/Endpoints/Workflow/ListWorkflows/Models.cs
@@ -29,5 +29,5 @@ public class Response
     /// <summary>
     /// Gets or sets the paginated result of workflows.
     /// </summary>
-    public required PaginatedResult<WorkflowDto?> Result { get; set; }
+    public PaginatedResult<WorkflowDto?> Result { get; set; } = null!;
 }

--- a/tests/Architecture.Tests/WebApiEndpointSourceTests.cs
+++ b/tests/Architecture.Tests/WebApiEndpointSourceTests.cs
@@ -3,6 +3,36 @@ namespace Architecture.Tests;
 public class WebApiEndpointSourceTests
 {
     [Fact]
+    public void WebApi_Response_Dtos_Should_Not_Use_Required_Members()
+    {
+        var repoRoot = LocateRepositoryRoot();
+        var modelFiles = Directory.GetFiles(
+            Path.Combine(repoRoot, "src", "WebApi", "Endpoints"),
+            "Models.cs",
+            SearchOption.AllDirectories);
+
+        var requiredResponseMemberPattern = new System.Text.RegularExpressions.Regex(
+            @"public\s+class\s+Response[\s\S]*?\{(?<body>[\s\S]*?)^\}",
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+
+        var offenders = modelFiles
+            .Select(path => new
+            {
+                Path = Path.GetRelativePath(repoRoot, path),
+                Text = File.ReadAllText(path)
+            })
+            .SelectMany(file => requiredResponseMemberPattern
+                .Matches(file.Text)
+                .Cast<System.Text.RegularExpressions.Match>()
+                .Where(match => match.Groups["body"].Value.Contains("public required "))
+                .Select(_ => file.Path))
+            .OrderBy(path => path)
+            .ToArray();
+
+        offenders.Should().BeEmpty("FastEndpoints creates response DTOs reflectively before handlers assign properties, and required response members make that instantiation fail at runtime");
+    }
+
+    [Fact]
     public void WebApi_Endpoints_Should_Not_Pass_CancellationToken_As_FindAsync_Key()
     {
         var repoRoot = LocateRepositoryRoot();

--- a/tests/WebApi.Unit.Tests/Endpoints/ImpedimentEndpointsTests.cs
+++ b/tests/WebApi.Unit.Tests/Endpoints/ImpedimentEndpointsTests.cs
@@ -49,6 +49,42 @@ public class ImpedimentEndpointsTests
     }
 
     [Test]
+    public async Task ListImpediments_WithValidPagination_ShouldReturnPaginatedImpediments()
+    {
+        // Arrange
+        var firstImpedimentId = Guid.NewGuid();
+        var secondImpedimentId = Guid.NewGuid();
+        var firstImpediment = Impediment.Create("Blocked dependency", firstImpedimentId);
+        var secondImpediment = Impediment.Create("Missing access", secondImpedimentId);
+
+        await using var dbContext = CreateDbContext();
+        dbContext.Impediments!.AddRange(firstImpediment, secondImpediment);
+        await dbContext.SaveChangesAsync(default);
+
+        var ep = Factory.Create<WebApi.Endpoints.Impediment.ListImpediments.Endpoint>(dbContext);
+        var req = new WebApi.Endpoints.Impediment.ListImpediments.Request
+        {
+            Pagination = new PaginationParams
+            {
+                PageNumber = 1,
+                PageSize = 10,
+                SortColumn = "Name",
+                SortOrder = "ASC"
+            }
+        };
+
+        // Act
+        await ep.HandleAsync(req, default);
+
+        // Assert
+        ep.Response.ShouldNotBeNull();
+        ep.Response.Result.ShouldNotBeNull();
+        ep.Response.Result.TotalCount.ShouldBe(2);
+        ep.Response.Result.Data.ShouldNotBeNull();
+        ep.Response.Result.Data.Count().ShouldBe(2);
+    }
+
+    [Test]
     public async Task UpdateImpediment_WithValidData_ShouldUpdateImpediment()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- remove C# `required` members from WebApi list response DTO `Result` properties so FastEndpoints can instantiate response DTOs before handlers assign them
- add a regression test for `ListImpediments_WithValidPagination` covering the reported runtime exception
- add an architecture guard preventing required members on WebApi `Response` DTOs

## Validation
- `dotnet test tests/Architecture.Tests/ --no-restore`
- `dotnet test tests/WebApi.Unit.Tests/ --filter "FullyQualifiedName~ImpedimentEndpointsTests" --no-restore`

Fixes the reported `/impediments` error: `Unable to create an instance of the response DTO. Please create it yourself and assign to the [Response] property!`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated API response model configurations across multiple list endpoints to improve initialization patterns and flexibility.

* **Tests**
  * Added architectural validation test to ensure API response models follow consistent patterns.
  * Added comprehensive unit test for the ListImpediments endpoint with pagination verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->