### PR TITLE
fix: canonicalize WebClient static routes

### DIFF
--- a/src/WebClient/src/layouts/AppLayout.astro
+++ b/src/WebClient/src/layouts/AppLayout.astro
@@ -5,16 +5,20 @@ import { ThemeToggle } from '../components/theme-toggle';
 
 const groups = [
   { name: 'Start', items: [
-    ['Home', '/'], ['Organizations', '/organizations'], ['Projects', '/projects'], ['Tasks', '/assignments'], ['Progress steps', '/workflows'], ['Calendar', '/appointments'],
+    ['Home', '/'], ['Organizations', '/organizations/'], ['Projects', '/projects/'], ['Tasks', '/assignments/'], ['Progress steps', '/workflows/'], ['Calendar', '/appointments/'],
   ] },
-  { name: 'People', items: [['Team members', '/users'], ['People on tasks', '/user-assignments'], ['People on projects', '/user-projects']] },
-  { name: 'Setup', items: [['Task types', '/assignment-types'], ['Blockers', '/impediments'], ['Task blockers', '/assignment-impediments']] },
-  { name: 'Status', items: [['Service health', '/api-health']] },
+  { name: 'People', items: [['Team members', '/users/'], ['People on tasks', '/user-assignments/'], ['People on projects', '/user-projects/']] },
+  { name: 'Setup', items: [['Task types', '/assignment-types/'], ['Blockers', '/impediments/'], ['Task blockers', '/assignment-impediments/']] },
+  { name: 'Status', items: [['Service health', '/api-health/']] },
 ] as const;
 
 const { path = '/' } = Astro.props;
 const pathname = path.replace(/\/$/, '') || '/';
-const isActive = (href: string) => href === '/' ? pathname === '/' : pathname === href || pathname.startsWith(`${href}/`);
+const normalizePath = (href: string) => href.replace(/\/$/, '') || '/';
+const isActive = (href: string) => {
+  const normalizedHref = normalizePath(href);
+  return normalizedHref === '/' ? pathname === '/' : pathname === normalizedHref || pathname.startsWith(`${normalizedHref}/`);
+};
 ---
 
 <html lang="en" data-theme="dark" style="color-scheme: dark;">

--- a/src/WebClient/src/lib/api/http-client.test.ts
+++ b/src/WebClient/src/lib/api/http-client.test.ts
@@ -19,6 +19,7 @@ Object.defineProperty(globalThis, 'sessionStorage', {
 
 afterEach(() => {
   sessionStorage.clear();
+  Reflect.deleteProperty(globalThis, 'window');
   vi.restoreAllMocks();
 });
 
@@ -41,5 +42,28 @@ describe('http client token handling', () => {
     setStoredToken(tokenWithIssuer('https://identity-cpnucleo.jonathanperis.tech'));
     await requestJson('http://example.test');
     expect(new Headers(fetchMock.mock.calls[1][1]?.headers).get('Authorization')).toMatch(/^Bearer /);
+  });
+
+  it('redirects expired sessions to the canonical trailing-slash login route without leaking the current port', async () => {
+    const assign = vi.fn();
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          pathname: '/projects',
+          search: '?page=2',
+          hash: '',
+          origin: 'https://cpnucleo.jonathanperis.tech:5030',
+          assign,
+        },
+      },
+      configurable: true,
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ title: 'Unauthorized' }), { status: 401 }));
+
+    await expect(requestJson('http://example.test')).rejects.toMatchObject({ status: 401 });
+
+    expect(assign).toHaveBeenCalledWith('/login/?returnUrl=%2Fprojects%2F%3Fpage%3D2');
+    expect(assign.mock.calls[0][0]).not.toContain('5030');
+    expect(assign.mock.calls[0][0]).not.toContain('cpnucleo.jonathanperis.tech');
   });
 });

--- a/src/WebClient/src/lib/api/http-client.ts
+++ b/src/WebClient/src/lib/api/http-client.ts
@@ -1,5 +1,6 @@
 import type { ApiErrorShape } from './types';
 import { IDENTITY_API_ISSUER } from '../config';
+import { getLoginRedirectTarget } from '../auth-navigation';
 
 export class ApiError extends Error implements ApiErrorShape {
   status: number;
@@ -55,9 +56,8 @@ export const clearStoredToken = (): void => {
 
 const redirectToLoginForExpiredSession = () => {
   if (typeof window === 'undefined') return;
-  if (window.location.pathname === '/login') return;
-  const returnUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-  window.location.assign(`/login?returnUrl=${encodeURIComponent(returnUrl)}`);
+  if (window.location.pathname === '/login' || window.location.pathname === '/login/') return;
+  window.location.assign(getLoginRedirectTarget(window.location));
 };
 
 const errorMessage = (status: number, body: unknown): string => {

--- a/src/WebClient/src/lib/api/resource-metadata.test.ts
+++ b/src/WebClient/src/lib/api/resource-metadata.test.ts
@@ -10,6 +10,10 @@ describe('resource metadata', () => {
     expect(resourceMetadata.every((resource) => resource.listPath.startsWith('/') && resource.itemPath.startsWith('/'))).toBe(true);
   });
 
+  it('uses canonical trailing-slash static page routes', () => {
+    expect(resourceMetadata.every((resource) => resource.routePath.startsWith('/') && resource.routePath.endsWith('/'))).toBe(true);
+  });
+
   it('keeps passwords out of user table/form metadata', () => {
     const users = resourceMetadata.find((resource) => resource.key === 'users');
     expect(users).toBeDefined();

--- a/src/WebClient/src/lib/api/resource-metadata.ts
+++ b/src/WebClient/src/lib/api/resource-metadata.ts
@@ -17,15 +17,15 @@ const resource = (
 ): ResourceMetadata => ({ key, label, pluralLabel, listPath: `/${key}`, itemPath: `/${itemPath}`, routePath, description, displayField, fields: [...baseFields, ...fields] });
 
 export const resourceMetadata = [
-  resource('organizations', 'Organization', 'Organizations', 'organization', '/organizations', 'Teams and groups that own projects.', 'name', [
+  resource('organizations', 'Organization', 'Organizations', 'organization', '/organizations/', 'Teams and groups that own projects.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'description', label: 'Description', type: 'textarea', table: true },
   ]),
-  resource('projects', 'Project', 'Projects', 'project', '/projects', 'Project spaces connected to an organization.', 'name', [
+  resource('projects', 'Project', 'Projects', 'project', '/projects/', 'Project spaces connected to an organization.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'organizationId', label: 'Organization', type: 'guid', required: true, table: true, relation: 'organizations' },
   ]),
-  resource('assignments', 'Task', 'Tasks', 'assignment', '/assignments', 'Work items with dates, hours, progress, and owner links.', 'name', [
+  resource('assignments', 'Task', 'Tasks', 'assignment', '/assignments/', 'Work items with dates, hours, progress, and owner links.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'description', label: 'Description', type: 'textarea', table: true },
     { name: 'startDate', label: 'Start date', type: 'date', table: true },
@@ -36,37 +36,37 @@ export const resourceMetadata = [
     { name: 'userId', label: 'Owner', type: 'guid', table: true, relation: 'users' },
     { name: 'assignmentTypeId', label: 'Task type', type: 'guid', table: true, relation: 'assignmentTypes' },
   ]),
-  resource('assignmentTypes', 'Task type', 'Task types', 'assignmentType', '/assignment-types', 'Reusable labels for different kinds of work.', 'name', [
+  resource('assignmentTypes', 'Task type', 'Task types', 'assignmentType', '/assignment-types/', 'Reusable labels for different kinds of work.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
   ]),
-  resource('impediments', 'Blocker', 'Blockers', 'impediment', '/impediments', 'Issues that may slow work down.', 'name', [
+  resource('impediments', 'Blocker', 'Blockers', 'impediment', '/impediments/', 'Issues that may slow work down.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
   ]),
-  resource('assignmentImpediments', 'Task blocker', 'Task blockers', 'assignmentImpediment', '/assignment-impediments', 'Notes that connect blockers to a task.', 'description', [
+  resource('assignmentImpediments', 'Task blocker', 'Task blockers', 'assignmentImpediment', '/assignment-impediments/', 'Notes that connect blockers to a task.', 'description', [
     { name: 'description', label: 'Description', type: 'textarea', required: true, table: true },
     { name: 'assignmentId', label: 'Task', type: 'guid', required: true, table: true, relation: 'assignments' },
     { name: 'impedimentId', label: 'Blocker', type: 'guid', required: true, table: true, relation: 'impediments' },
   ]),
-  resource('appointments', 'Calendar item', 'Calendar items', 'appointment', '/appointments', 'Scheduled moments connected to people and tasks.', 'description', [
+  resource('appointments', 'Calendar item', 'Calendar items', 'appointment', '/appointments/', 'Scheduled moments connected to people and tasks.', 'description', [
     { name: 'description', label: 'Description', type: 'textarea', required: true, table: true },
     { name: 'keepDate', label: 'Date', type: 'datetime-local', required: true, table: true },
     { name: 'amountHours', label: 'Hours', type: 'number', table: true },
     { name: 'assignmentId', label: 'Task', type: 'guid', required: true, table: true, relation: 'assignments' },
     { name: 'userId', label: 'Person', type: 'guid', required: true, table: true, relation: 'users' },
   ]),
-  resource('workflows', 'Progress step', 'Progress steps', 'workflow', '/workflows', 'Steps that show where a task is in the work path.', 'name', [
+  resource('workflows', 'Progress step', 'Progress steps', 'workflow', '/workflows/', 'Steps that show where a task is in the work path.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'order', label: 'Order', type: 'number', table: true },
   ]),
-  resource('users', 'Team member', 'Team members', 'user', '/users', 'People who can own projects, tasks, and calendar items.', 'name', [
+  resource('users', 'Team member', 'Team members', 'user', '/users/', 'People who can own projects, tasks, and calendar items.', 'name', [
     { name: 'name', label: 'Name', type: 'text', required: true, table: true },
     { name: 'login', label: 'Login', type: 'text', required: true, table: true },
   ]),
-  resource('userAssignments', 'Person on task', 'People on tasks', 'userAssignment', '/user-assignments', 'Connections between people and the tasks they help with.', 'id', [
+  resource('userAssignments', 'Person on task', 'People on tasks', 'userAssignment', '/user-assignments/', 'Connections between people and the tasks they help with.', 'id', [
     { name: 'userId', label: 'Person', type: 'guid', required: true, table: true, relation: 'users' },
     { name: 'assignmentId', label: 'Task', type: 'guid', required: true, table: true, relation: 'assignments' },
   ]),
-  resource('userProjects', 'Person on project', 'People on projects', 'userProject', '/user-projects', 'Connections between people and their project spaces.', 'id', [
+  resource('userProjects', 'Person on project', 'People on projects', 'userProject', '/user-projects/', 'Connections between people and their project spaces.', 'id', [
     { name: 'userId', label: 'Person', type: 'guid', required: true, table: true, relation: 'users' },
     { name: 'projectId', label: 'Project', type: 'guid', required: true, table: true, relation: 'projects' },
   ]),

--- a/src/WebClient/src/lib/auth-navigation.test.ts
+++ b/src/WebClient/src/lib/auth-navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getLoginPath, getLoginRedirectTarget, getPostLoginRedirectTarget } from './auth-navigation';
+import { canonicalizeStaticRoute, getLoginPath, getLoginRedirectTarget, getPostLoginRedirectTarget } from './auth-navigation';
 
 describe('auth navigation', () => {
   it('redirects protected pages to the trailing-slash login route without leaking the internal container port', () => {
@@ -12,16 +12,25 @@ describe('auth navigation', () => {
 
   it('keeps protected return urls relative', () => {
     expect(getLoginRedirectTarget({ pathname: '/projects', search: '?page=2', origin: 'https://cpnucleo.jonathanperis.tech:5030' }))
-      .toBe('/login/?returnUrl=%2Fprojects%3Fpage%3D2');
+      .toBe('/login/?returnUrl=%2Fprojects%2F%3Fpage%3D2');
   });
 
   it('rejects absolute and protocol-relative post-login return urls', () => {
     expect(getPostLoginRedirectTarget('https://evil.test/projects')).toBe('/');
     expect(getPostLoginRedirectTarget('//evil.test/projects')).toBe('/');
-    expect(getPostLoginRedirectTarget('/projects')).toBe('/projects');
+    expect(getPostLoginRedirectTarget('/projects')).toBe('/projects/');
+    expect(getPostLoginRedirectTarget('/projects?page=2#tasks')).toBe('/projects/?page=2#tasks');
   });
 
   it('uses the canonical standalone login path', () => {
     expect(getLoginPath()).toBe('/login/');
+  });
+
+  it('canonicalizes generated static page routes with trailing slashes', () => {
+    expect(canonicalizeStaticRoute('/organizations')).toBe('/organizations/');
+    expect(canonicalizeStaticRoute('/projects/')).toBe('/projects/');
+    expect(canonicalizeStaticRoute('/assignments')).toBe('/assignments/');
+    expect(canonicalizeStaticRoute('/api-health')).toBe('/api-health/');
+    expect(canonicalizeStaticRoute('/api/projects')).toBe('/api/projects');
   });
 });

--- a/src/WebClient/src/lib/auth-navigation.ts
+++ b/src/WebClient/src/lib/auth-navigation.ts
@@ -1,10 +1,31 @@
 export const getLoginPath = () => '/login/';
 
-type LocationLike = Pick<Location, 'pathname' | 'search'> & { origin?: string };
+type LocationLike = Pick<Location, 'pathname' | 'search'> & { hash?: string; origin?: string };
 
-export const getLoginRedirectTarget = ({ pathname, search }: LocationLike): string => {
+const canonicalStaticRoutes = new Set([
+  '/login',
+  '/organizations',
+  '/projects',
+  '/assignments',
+  '/assignment-types',
+  '/impediments',
+  '/assignment-impediments',
+  '/appointments',
+  '/workflows',
+  '/users',
+  '/user-assignments',
+  '/user-projects',
+  '/api-health',
+]);
+
+export const canonicalizeStaticRoute = (pathname: string): string => {
+  const normalized = pathname.replace(/\/$/, '') || '/';
+  return canonicalStaticRoutes.has(normalized) ? `${normalized}/` : pathname;
+};
+
+export const getLoginRedirectTarget = ({ pathname, search, hash = '' }: LocationLike): string => {
   const loginPath = getLoginPath();
-  const current = `${pathname}${search}`;
+  const current = `${canonicalizeStaticRoute(pathname)}${search}${hash}`;
   const isLoginPage = pathname === '/login' || pathname === loginPath;
   const returnUrl = current && current !== '/' && !isLoginPage
     ? `?returnUrl=${encodeURIComponent(current)}`
@@ -18,5 +39,6 @@ export const getPostLoginRedirectTarget = (returnUrl: string | null): string => 
     return '/';
   }
 
-  return returnUrl;
+  const parsed = new URL(returnUrl, 'https://cpnucleo.local');
+  return `${canonicalizeStaticRoute(parsed.pathname)}${parsed.search}${parsed.hash}`;
 };

--- a/src/WebClient/src/routes/index.tsx
+++ b/src/WebClient/src/routes/index.tsx
@@ -3,10 +3,10 @@ import { resourceMetadata } from '~/lib/api/resource-metadata';
 import { webApiClient } from '~/lib/api/webapi-client';
 
 const shortcuts = [
-  ['Project overview', 'See what the app does, where the main work areas are, and where to begin.', '/projects'],
-  ['People and access', 'Review team members and the work they are connected to.', '/users'],
-  ['Data and storage', 'Browse the core records that keep projects, tasks, blockers, and calendar items connected.', '/organizations'],
-  ['Checks and status', 'Confirm the app services are reachable before you keep working.', '/api-health'],
+  ['Project overview', 'See what the app does, where the main work areas are, and where to begin.', '/projects/'],
+  ['People and access', 'Review team members and the work they are connected to.', '/users/'],
+  ['Data and storage', 'Browse the core records that keep projects, tasks, blockers, and calendar items connected.', '/organizations/'],
+  ['Checks and status', 'Confirm the app services are reachable before you keep working.', '/api-health/'],
 ] as const;
 
 export default component$(() => {
@@ -31,8 +31,8 @@ export default component$(() => {
             <h2 class="mt-5 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">Choose where to start in Cpnucleo.</h2>
             <p class="mt-4 max-w-2xl text-base leading-7 text-muted">Use this space to review projects, people, tasks, blockers, calendar items, and service status without digging through setup details first.</p>
             <div class="mt-7 flex flex-wrap gap-3">
-              <a class="rounded-xl bg-ink px-5 py-3 text-sm font-semibold text-canvas shadow-soft transition hover:opacity-90" href="/projects">Open projects</a>
-              <a class="rounded-xl border border-line bg-raised px-5 py-3 text-sm font-semibold transition hover:border-accent/40 hover:text-accent" href="/api-health">Check service status</a>
+              <a class="rounded-xl bg-ink px-5 py-3 text-sm font-semibold text-canvas shadow-soft transition hover:opacity-90" href="/projects/">Open projects</a>
+              <a class="rounded-xl border border-line bg-raised px-5 py-3 text-sm font-semibold transition hover:border-accent/40 hover:text-accent" href="/api-health/">Check service status</a>
             </div>
           </div>
           <div class="rounded-[1.5rem] border border-line bg-raised p-5">


### PR DESCRIPTION
## Summary
- use canonical trailing-slash WebClient routes for static pages so nginx directory normalization does not expose the internal `:5030` port behind the proxy
- route expired-session redirects through the shared login navigation helper, using `/login/` and origin-relative return URLs
- canonicalize post-login return URLs for known static routes and add regression coverage for the reported pages

## Validation
- `bun run typecheck`
- `bun test`
- `bun run build`
- generated HTML/JS scan confirms no extensionless app links or `:5030` public host references
- local preview smoke: `/organizations/`, `/projects/`, `/assignments/`, `/api-health/` all returned 200 with no redirect