### PR TITLE
feat: expire inactive sessions and refresh tokens

### DIFF
--- a/src/IdentityApi/Endpoints/Login/Endpoint.cs
+++ b/src/IdentityApi/Endpoints/Login/Endpoint.cs
@@ -43,6 +43,7 @@ public class Endpoint(IApplicationDbContext dbContext, IPasswordHasher passwordH
         var jwtToken = JwtBearer.CreateToken(
             o =>
             {
+                o.ExpireAt = DateTime.UtcNow.AddMinutes(30);
                 // o.User.Roles.Add("Manager", "Auditor");
                 // o.User.Claims.Add(("UserName", req.Username));
                 // o.User["UserId"] = "001"; //indexer based claim setting

--- a/src/IdentityApi/Endpoints/Refresh/Endpoint.cs
+++ b/src/IdentityApi/Endpoints/Refresh/Endpoint.cs
@@ -1,0 +1,25 @@
+namespace IdentityApi.Endpoints.Refresh;
+
+public class Endpoint : EndpointWithoutRequest<Response>
+{
+    public override void Configure()
+    {
+        Post("/refresh");
+        Description(x => x.WithTags("Authentication"));
+
+        Summary(s =>
+        {
+            s.Summary = "Refresh authenticated user session";
+            s.Description = "Issues a new 30-minute JWT for an already authenticated session.";
+        });
+    }
+
+    public override async Task HandleAsync(CancellationToken cancellationToken)
+    {
+        Logger.LogInformation("Refreshing JWT token for an active session.");
+
+        Response.Token = JwtBearer.CreateToken(o => { });
+
+        await Send.OkAsync(Response, cancellationToken);
+    }
+}

--- a/src/IdentityApi/Endpoints/Refresh/Endpoint.cs
+++ b/src/IdentityApi/Endpoints/Refresh/Endpoint.cs
@@ -18,7 +18,10 @@ public class Endpoint : EndpointWithoutRequest<Response>
     {
         Logger.LogInformation("Refreshing JWT token for an active session.");
 
-        Response.Token = JwtBearer.CreateToken(o => { });
+        Response.Token = JwtBearer.CreateToken(o =>
+        {
+            o.ExpireAt = DateTime.UtcNow.AddMinutes(30);
+        });
 
         await Send.OkAsync(Response, cancellationToken);
     }

--- a/src/IdentityApi/Endpoints/Refresh/Models.cs
+++ b/src/IdentityApi/Endpoints/Refresh/Models.cs
@@ -1,0 +1,12 @@
+namespace IdentityApi.Endpoints.Refresh;
+
+/// <summary>
+/// Represents a refreshed user session response.
+/// </summary>
+public class Response
+{
+    /// <summary>
+    /// A renewed 30-minute JWT for the authenticated user session.
+    /// </summary>
+    public string? Token { get; set; }
+}

--- a/src/IdentityApi/Endpoints/Refresh/Models.cs
+++ b/src/IdentityApi/Endpoints/Refresh/Models.cs
@@ -8,5 +8,5 @@ public class Response
     /// <summary>
     /// A renewed 30-minute JWT for the authenticated user session.
     /// </summary>
-    public string? Token { get; set; }
+    public string Token { get; set; } = string.Empty;
 }

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -26,7 +26,6 @@ builder.Services.AddCors(options =>
 builder.Services
     .Configure<JwtCreationOptions>(o =>
     {
-        o.ExpireAt = DateTime.UtcNow.AddMinutes(30);
         o.SigningKey = builder.Configuration["Jwt:SigningKey"] ?? throw new InvalidOperationException("Jwt:SigningKey configuration is missing.");
         o.Issuer = builder.Configuration["Jwt:Issuer"] ?? throw new InvalidOperationException("Jwt:Issuer configuration is missing.");
         o.Audience = builder.Configuration["Jwt:Audience"] ?? throw new InvalidOperationException("Jwt:Audience configuration is missing.");

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddCors(options =>
 builder.Services
     .Configure<JwtCreationOptions>(o =>
     {
-        o.ExpireAt = DateTime.UtcNow.AddDays(1);
+        o.ExpireAt = DateTime.UtcNow.AddMinutes(30);
         o.SigningKey = builder.Configuration["Jwt:SigningKey"] ?? throw new InvalidOperationException("Jwt:SigningKey configuration is missing.");
         o.Issuer = builder.Configuration["Jwt:Issuer"] ?? throw new InvalidOperationException("Jwt:Issuer configuration is missing.");
         o.Audience = builder.Configuration["Jwt:Audience"] ?? throw new InvalidOperationException("Jwt:Audience configuration is missing.");

--- a/src/WebClient/src/components/auth-guard.tsx
+++ b/src/WebClient/src/components/auth-guard.tsx
@@ -1,5 +1,5 @@
 import { component$, Slot, useSignal, useVisibleTask$ } from '@builder.io/qwik';
-import { clearStoredToken, getStoredToken } from '~/lib/api/http-client';
+import { clearStoredToken, getStoredToken, setupSessionActivityTracking } from '~/lib/api/http-client';
 import { getLoginPath, getLoginRedirectTarget } from '~/lib/auth-navigation';
 
 const loginPath = getLoginPath();
@@ -14,7 +14,10 @@ export const AuthGuard = component$(() => {
     checked.value = true;
     if (!token) {
       window.location.replace(getLoginRedirectTarget(window.location));
+      return;
     }
+
+    return setupSessionActivityTracking();
   });
 
   if (!checked.value) {

--- a/src/WebClient/src/lib/api/http-client.test.ts
+++ b/src/WebClient/src/lib/api/http-client.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getStoredToken, requestJson, setStoredToken } from './http-client';
+import { getStoredToken, lastActivityStorageKey, requestJson, sessionInactivityTimeoutMs, setStoredToken, tokenStorageKey } from './http-client';
 
-const tokenWithIssuer = (issuer: string) => {
+const tokenWithPayload = (payload: Record<string, unknown>) => {
   const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64url');
-  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode({ iss: issuer, sub: 'user-1' })}.signature`;
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.signature`;
 };
+
+const tokenWithIssuer = (issuer: string, extraPayload: Record<string, unknown> = {}) =>
+  tokenWithPayload({ iss: issuer, sub: 'user-1', ...extraPayload });
 
 const storage = new Map<string, string>();
 Object.defineProperty(globalThis, 'sessionStorage', {
@@ -42,6 +45,34 @@ describe('http client token handling', () => {
     setStoredToken(tokenWithIssuer('https://identity-cpnucleo.jonathanperis.tech'));
     await requestJson('http://example.test');
     expect(new Headers(fetchMock.mock.calls[1][1]?.headers).get('Authorization')).toMatch(/^Bearer /);
+  });
+
+  it('omits bearer tokens when a request explicitly disables auth', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    setStoredToken(tokenWithIssuer('https://identity-cpnucleo.jonathanperis.tech'));
+    await requestJson('http://example.test/login', { method: 'POST', token: null });
+
+    expect(new Headers(fetchMock.mock.calls[0][1]?.headers).has('Authorization')).toBe(false);
+  });
+
+  it('removes the token after 15 minutes of inactivity', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-05-25T12:00:00Z'));
+    setStoredToken(tokenWithIssuer('https://identity-cpnucleo.jonathanperis.tech', { exp: Math.floor(Date.now() / 1000) + 1800 }));
+    expect(getStoredToken()).toBeTruthy();
+
+    sessionStorage.setItem(lastActivityStorageKey, String(Date.now() - sessionInactivityTimeoutMs - 1));
+
+    expect(getStoredToken()).toBeNull();
+    expect(sessionStorage.getItem(tokenStorageKey)).toBeNull();
+  });
+
+  it('does not keep already expired 30-minute tokens', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-05-25T12:00:00Z'));
+
+    setStoredToken(tokenWithIssuer('https://identity-cpnucleo.jonathanperis.tech', { exp: Math.floor(Date.now() / 1000) - 1 }));
+
+    expect(getStoredToken()).toBeNull();
   });
 
   it('redirects expired sessions to the canonical trailing-slash login route without leaking the current port', async () => {

--- a/src/WebClient/src/lib/api/http-client.ts
+++ b/src/WebClient/src/lib/api/http-client.ts
@@ -1,5 +1,5 @@
 import type { ApiErrorShape } from './types';
-import { IDENTITY_API_ISSUER } from '../config';
+import { IDENTITY_API_BASE_URL, IDENTITY_API_ISSUER } from '../config';
 import { getLoginRedirectTarget } from '../auth-navigation';
 
 export class ApiError extends Error implements ApiErrorShape {
@@ -15,15 +15,26 @@ export class ApiError extends Error implements ApiErrorShape {
 }
 
 export const tokenStorageKey = 'cpnucleo.jwt';
+export const lastActivityStorageKey = 'cpnucleo.lastActivityAt';
+export const sessionInactivityTimeoutMs = 15 * 60 * 1000;
+export const tokenRefreshLeadMs = 5 * 60 * 1000;
+const tokenRefreshCooldownMs = 60 * 1000;
 
-const decodeJwtPayload = (token: string): { iss?: unknown } | null => {
+let inactivityTimer: number | undefined;
+let refreshTimer: number | undefined;
+let refreshInFlight: Promise<boolean> | undefined;
+let lastRefreshAttemptAt = 0;
+
+const now = () => Date.now();
+
+const decodeJwtPayload = (token: string): { iss?: unknown; exp?: unknown } | null => {
   const payload = token.split('.')[1];
   if (!payload) return null;
 
   try {
     const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
     const padded = normalized.padEnd(normalized.length + ((4 - normalized.length % 4) % 4), '=');
-    return JSON.parse(atob(padded)) as { iss?: unknown };
+    return JSON.parse(atob(padded)) as { iss?: unknown; exp?: unknown };
   } catch {
     return null;
   }
@@ -32,32 +43,164 @@ const decodeJwtPayload = (token: string): { iss?: unknown } | null => {
 export const tokenWasIssuedByIdentityApi = (token: string, issuer = IDENTITY_API_ISSUER): boolean =>
   decodeJwtPayload(token)?.iss === issuer;
 
+const getTokenExpiresAt = (token: string): number | null => {
+  const exp = decodeJwtPayload(token)?.exp;
+  return typeof exp === 'number' ? exp * 1000 : null;
+};
+
+const tokenHasExpired = (token: string, currentTime = now()) => {
+  const expiresAt = getTokenExpiresAt(token);
+  return expiresAt !== null && expiresAt <= currentTime;
+};
+
+const getLastActivityAt = (): number | null => {
+  if (typeof sessionStorage === 'undefined') return null;
+  const stored = Number(sessionStorage.getItem(lastActivityStorageKey));
+  return Number.isFinite(stored) && stored > 0 ? stored : null;
+};
+
+const sessionIsInactive = (currentTime = now()) => {
+  const lastActivityAt = getLastActivityAt();
+  return lastActivityAt !== null && currentTime - lastActivityAt >= sessionInactivityTimeoutMs;
+};
+
+const markSessionActivity = (currentTime = now()): void => {
+  if (typeof sessionStorage !== 'undefined') sessionStorage.setItem(lastActivityStorageKey, String(currentTime));
+};
+
 export const getStoredToken = (): string | null => {
   if (typeof sessionStorage === 'undefined') return null;
   const token = sessionStorage.getItem(tokenStorageKey);
   if (!token) return null;
-  if (tokenWasIssuedByIdentityApi(token)) return token;
-  sessionStorage.removeItem(tokenStorageKey);
+  if (tokenWasIssuedByIdentityApi(token) && !tokenHasExpired(token) && !sessionIsInactive()) return token;
+  clearStoredToken();
   return null;
 };
 
 export const setStoredToken = (token: string): void => {
   if (typeof sessionStorage === 'undefined') return;
-  if (tokenWasIssuedByIdentityApi(token)) {
+  if (tokenWasIssuedByIdentityApi(token) && !tokenHasExpired(token)) {
     sessionStorage.setItem(tokenStorageKey, token);
+    markSessionActivity();
+    scheduleSessionTimers();
     return;
   }
-  sessionStorage.removeItem(tokenStorageKey);
+  clearStoredToken();
 };
 
 export const clearStoredToken = (): void => {
-  if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(tokenStorageKey);
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.removeItem(tokenStorageKey);
+    sessionStorage.removeItem(lastActivityStorageKey);
+  }
+  if (inactivityTimer) clearTimeout(inactivityTimer);
+  if (refreshTimer) clearTimeout(refreshTimer);
+  inactivityTimer = undefined;
+  refreshTimer = undefined;
 };
 
 const redirectToLoginForExpiredSession = () => {
   if (typeof window === 'undefined') return;
   if (window.location.pathname === '/login' || window.location.pathname === '/login/') return;
   window.location.assign(getLoginRedirectTarget(window.location));
+};
+
+const refreshStoredToken = async (baseUrl = IDENTITY_API_BASE_URL): Promise<boolean> => {
+  const token = getStoredToken();
+  if (!token) return false;
+
+  if (refreshInFlight) return refreshInFlight;
+
+  refreshInFlight = (async () => {
+    let response: Response;
+    try {
+      response = await fetch(`${baseUrl.replace(/\/$/, '')}/refresh`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    } catch {
+      return false;
+    }
+
+    if (response.status === 401) {
+      clearStoredToken();
+      redirectToLoginForExpiredSession();
+      return false;
+    }
+
+    if (!response.ok) return false;
+
+    const body = await parseJson(response) as { token?: unknown } | undefined;
+    if (typeof body?.token !== 'string') return false;
+    setStoredToken(body.token);
+    return true;
+  })().finally(() => {
+    refreshInFlight = undefined;
+  });
+
+  return refreshInFlight;
+};
+
+const shouldRefreshToken = (token: string, currentTime = now()) => {
+  const expiresAt = getTokenExpiresAt(token);
+  return expiresAt !== null && expiresAt - currentTime <= tokenRefreshLeadMs;
+};
+
+const refreshTokenIfNeeded = () => {
+  const currentTime = now();
+  const token = getStoredToken();
+  if (!token || sessionIsInactive(currentTime) || !shouldRefreshToken(token, currentTime)) return;
+  if (currentTime - lastRefreshAttemptAt < tokenRefreshCooldownMs) return;
+  lastRefreshAttemptAt = currentTime;
+  void refreshStoredToken();
+};
+
+const scheduleSessionTimers = () => {
+  if (typeof window === 'undefined') return;
+
+  if (inactivityTimer) clearTimeout(inactivityTimer);
+  if (refreshTimer) clearTimeout(refreshTimer);
+
+  const token = getStoredToken();
+  if (!token) return;
+
+  const currentTime = now();
+  const lastActivityAt = getLastActivityAt() ?? currentTime;
+  const inactivityRemaining = Math.max(lastActivityAt + sessionInactivityTimeoutMs - currentTime, 0);
+  inactivityTimer = window.setTimeout(() => {
+    clearStoredToken();
+    redirectToLoginForExpiredSession();
+  }, inactivityRemaining);
+
+  const expiresAt = getTokenExpiresAt(token);
+  if (expiresAt === null) return;
+  const refreshIn = Math.max(expiresAt - tokenRefreshLeadMs - currentTime, 0);
+  refreshTimer = window.setTimeout(refreshTokenIfNeeded, refreshIn);
+};
+
+export const setupSessionActivityTracking = (): (() => void) => {
+  if (typeof window === 'undefined') return () => undefined;
+
+  const activityEvents = ['click', 'keydown', 'mousemove', 'scroll', 'touchstart'] as const;
+  const onActivity = () => {
+    if (!getStoredToken()) return;
+    markSessionActivity();
+    scheduleSessionTimers();
+    refreshTokenIfNeeded();
+  };
+
+  if (getStoredToken() && getLastActivityAt() === null) markSessionActivity();
+  scheduleSessionTimers();
+  activityEvents.forEach(event => window.addEventListener(event, onActivity, { passive: true }));
+
+  return () => {
+    activityEvents.forEach(event => window.removeEventListener(event, onActivity));
+    if (inactivityTimer) clearTimeout(inactivityTimer);
+    if (refreshTimer) clearTimeout(refreshTimer);
+  };
 };
 
 const errorMessage = (status: number, body: unknown): string => {
@@ -94,7 +237,8 @@ export interface HttpOptions extends RequestInit {
 }
 
 export const requestJson = async <T>(url: string, options: HttpOptions = {}): Promise<T> => {
-  const token = options.token ?? getStoredToken();
+  const token = options.token === undefined ? getStoredToken() : options.token;
+  if (token) markSessionActivity();
   const headers = new Headers(options.headers);
   if (!headers.has('Accept')) headers.set('Accept', 'application/json');
   if (options.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
@@ -114,5 +258,6 @@ export const requestJson = async <T>(url: string, options: HttpOptions = {}): Pr
     }
     throw new ApiError(response.status, errorMessage(response.status, body), body);
   }
+  refreshTokenIfNeeded();
   return body as T;
 };

--- a/src/WebClient/src/lib/api/http-client.ts
+++ b/src/WebClient/src/lib/api/http-client.ts
@@ -19,6 +19,7 @@ export const lastActivityStorageKey = 'cpnucleo.lastActivityAt';
 export const sessionInactivityTimeoutMs = 15 * 60 * 1000;
 export const tokenRefreshLeadMs = 5 * 60 * 1000;
 const tokenRefreshCooldownMs = 60 * 1000;
+const activityThrottleMs = 250;
 
 let inactivityTimer: number | undefined;
 let refreshTimer: number | undefined;
@@ -181,23 +182,37 @@ const scheduleSessionTimers = () => {
   refreshTimer = window.setTimeout(refreshTokenIfNeeded, refreshIn);
 };
 
+const throttleLeading = (callback: () => void, waitMs: number): (() => void) => {
+  let lastCalledAt = 0;
+  return () => {
+    const currentTime = now();
+    if (currentTime - lastCalledAt < waitMs) return;
+    lastCalledAt = currentTime;
+    callback();
+  };
+};
+
 export const setupSessionActivityTracking = (): (() => void) => {
   if (typeof window === 'undefined') return () => undefined;
 
-  const activityEvents = ['click', 'keydown', 'mousemove', 'scroll', 'touchstart'] as const;
+  const highFrequencyActivityEvents = ['mousemove', 'scroll'] as const;
+  const lowFrequencyActivityEvents = ['click', 'keydown', 'touchstart'] as const;
   const onActivity = () => {
     if (!getStoredToken()) return;
     markSessionActivity();
     scheduleSessionTimers();
     refreshTokenIfNeeded();
   };
+  const onHighFrequencyActivity = throttleLeading(onActivity, activityThrottleMs);
 
   if (getStoredToken() && getLastActivityAt() === null) markSessionActivity();
   scheduleSessionTimers();
-  activityEvents.forEach(event => window.addEventListener(event, onActivity, { passive: true }));
+  highFrequencyActivityEvents.forEach(event => window.addEventListener(event, onHighFrequencyActivity, { passive: true }));
+  lowFrequencyActivityEvents.forEach(event => window.addEventListener(event, onActivity, { passive: true }));
 
   return () => {
-    activityEvents.forEach(event => window.removeEventListener(event, onActivity));
+    highFrequencyActivityEvents.forEach(event => window.removeEventListener(event, onHighFrequencyActivity));
+    lowFrequencyActivityEvents.forEach(event => window.removeEventListener(event, onActivity));
     if (inactivityTimer) clearTimeout(inactivityTimer);
     if (refreshTimer) clearTimeout(refreshTimer);
   };

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -199,6 +199,33 @@ public class FastEndpointsConfigurationTests
         anonymousEndpoints.Should().BeEmpty("WebApi endpoints must require IdentityApi-issued bearer tokens");
     }
 
+    [Fact]
+    public void IdentityApi_ShouldIssueThirtyMinuteTokensAndRefreshAuthenticatedSessions()
+    {
+        var program = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Program.cs"));
+        var refreshEndpoint = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Endpoints/Refresh/Endpoint.cs"));
+
+        program.Should().Contain("o.ExpireAt = DateTime.UtcNow.AddMinutes(30)");
+        refreshEndpoint.Should().Contain("Post(\"/refresh\")");
+        refreshEndpoint.Should().Contain("JwtBearer.CreateToken(o => { })");
+        refreshEndpoint.Should().NotContain("AllowAnonymous();", "refresh must require an authenticated bearer token");
+    }
+
+    [Fact]
+    public void WebClient_ShouldExpireInactiveSessionsAndRefreshActiveTokens()
+    {
+        var httpClient = File.ReadAllText(GetRepositoryPath("src/WebClient/src/lib/api/http-client.ts"));
+        var authGuard = File.ReadAllText(GetRepositoryPath("src/WebClient/src/components/auth-guard.tsx"));
+
+        httpClient.Should().Contain("sessionInactivityTimeoutMs = 15 * 60 * 1000");
+        httpClient.Should().Contain("tokenRefreshLeadMs = 5 * 60 * 1000");
+        httpClient.Should().Contain("/refresh");
+        httpClient.Should().Contain("lastActivityStorageKey");
+        httpClient.Should().Contain("setupSessionActivityTracking");
+        httpClient.Should().Contain("redirectToLoginForExpiredSession()");
+        authGuard.Should().Contain("setupSessionActivityTracking()");
+    }
+
     [Theory]
     [InlineData("src/WebApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs", "webapi", true)]
     [InlineData("src/IdentityApi/ServiceExtensions/ConfigureOpenTelemetryOptions.cs", "identityapi", true)]

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -203,11 +203,14 @@ public class FastEndpointsConfigurationTests
     public void IdentityApi_ShouldIssueThirtyMinuteTokensAndRefreshAuthenticatedSessions()
     {
         var program = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Program.cs"));
+        var loginEndpoint = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Endpoints/Login/Endpoint.cs"));
         var refreshEndpoint = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Endpoints/Refresh/Endpoint.cs"));
 
-        program.Should().Contain("o.ExpireAt = DateTime.UtcNow.AddMinutes(30)");
+        program.Should().NotContain("o.ExpireAt = DateTime.UtcNow.AddMinutes(30)", "JWT expiry must be computed when each token is created, not once at startup");
+        loginEndpoint.Should().Contain("o.ExpireAt = DateTime.UtcNow.AddMinutes(30)");
+        refreshEndpoint.Should().Contain("o.ExpireAt = DateTime.UtcNow.AddMinutes(30)");
         refreshEndpoint.Should().Contain("Post(\"/refresh\")");
-        refreshEndpoint.Should().Contain("JwtBearer.CreateToken(o => { })");
+        refreshEndpoint.Should().Contain("JwtBearer.CreateToken(");
         refreshEndpoint.Should().NotContain("AllowAnonymous();", "refresh must require an authenticated bearer token");
     }
 


### PR DESCRIPTION
## Summary
- set IdentityApi JWTs to a 30-minute lifetime
- add authenticated /api/refresh endpoint to renew active sessions
- track WebClient activity, expire sessions after 15 minutes idle, and refresh near token expiry
- add WebClient and architecture regression coverage

## Verification
- bun test
- bun run typecheck
- /opt/data/home/.dotnet/dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore
- /opt/data/home/.dotnet/dotnet build src/IdentityApi/IdentityApi.csproj --no-restore

Note: dotnet commands still show existing NU1900 warnings because /opt/data/home/.local/share/NuGet/http-cache is not writable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions expire after 15 minutes of inactivity and active sessions proactively refresh tokens to avoid interruption
  * JWT lifespan reduced to 30 minutes; client schedules and throttles token refreshes and tracks user activity

* **Bug Fixes / Reliability**
  * Improved handling of expired or invalid tokens to ensure clean sign‑out and redirect to login

* **Tests**
  * Added tests validating JWT expiry, refresh behavior, and session inactivity handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->