### PR TITLE
Log health checks across services

### DIFF
--- a/src/GrpcServer/Program.cs
+++ b/src/GrpcServer/Program.cs
@@ -98,10 +98,7 @@ app.Use(async (context, next) =>
 
     if (context.Request.Path.Value?.Equals("/healthz", StringComparison.OrdinalIgnoreCase) == true)
     {
-        app.Logger.LogInformation("{Method} {Path} {StatusCode}",
-            context.Request.Method,
-            context.Request.Path,
-            context.Response.StatusCode);
+        app.Logger.LogInformation("GET /healthz {StatusCode}", context.Response.StatusCode);
     }
 });
 

--- a/src/GrpcServer/Program.cs
+++ b/src/GrpcServer/Program.cs
@@ -91,6 +91,20 @@ builder.Services.AddInfrastructure(builder.Configuration);
 var app = builder.Build();
 
 app.UseRateLimiter();
+
+app.Use(async (context, next) =>
+{
+    await next();
+
+    if (context.Request.Path.Value?.Equals("/healthz", StringComparison.OrdinalIgnoreCase) == true)
+    {
+        app.Logger.LogInformation("{Method} {Path} {StatusCode}",
+            context.Request.Method,
+            context.Request.Path,
+            context.Response.StatusCode);
+    }
+});
+
 app.UseHealthChecks("/healthz");
 
 app.UseInfrastructure();

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -115,6 +115,19 @@ var app = builder.Build();
 
 app.UseOutputCache();
 
+app.Use(async (context, next) =>
+{
+    await next();
+
+    if (context.Request.Path.Value?.Equals("/healthz", StringComparison.OrdinalIgnoreCase) == true)
+    {
+        app.Logger.LogInformation("{Method} {Path} {StatusCode}",
+            context.Request.Method,
+            context.Request.Path,
+            context.Response.StatusCode);
+    }
+});
+
 app.UseHealthChecks("/healthz");
 
 app.UseInfrastructure();

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -121,10 +121,7 @@ app.Use(async (context, next) =>
 
     if (context.Request.Path.Value?.Equals("/healthz", StringComparison.OrdinalIgnoreCase) == true)
     {
-        app.Logger.LogInformation("{Method} {Path} {StatusCode}",
-            context.Request.Method,
-            context.Request.Path,
-            context.Response.StatusCode);
+        app.Logger.LogInformation("GET /healthz {StatusCode}", context.Response.StatusCode);
     }
 });
 

--- a/src/IdentityApi/Program.cs
+++ b/src/IdentityApi/Program.cs
@@ -125,14 +125,15 @@ app.Use(async (context, next) =>
     }
 });
 
+app.UseCors("CpnucleoWebClient");
+
 app.UseHealthChecks("/healthz");
 
 app.UseInfrastructure();
 
 app.UseRateLimiter();
 
-app.UseCors("CpnucleoWebClient")
-    .UseAuthentication()
+app.UseAuthentication()
     .UseAuthorization()
     .UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api")
         .UseMiddleware<ElapsedTimeMiddleware>()

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -125,6 +125,19 @@ builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();
 
+app.Use(async (context, next) =>
+{
+    await next();
+
+    if (context.Request.Path.Value?.Equals("/healthz", StringComparison.OrdinalIgnoreCase) == true)
+    {
+        app.Logger.LogInformation("{Method} {Path} {StatusCode}",
+            context.Request.Method,
+            context.Request.Path,
+            context.Response.StatusCode);
+    }
+});
+
 app.UseHealthChecks("/healthz");
 
 app.UseInfrastructure();

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -131,10 +131,7 @@ app.Use(async (context, next) =>
 
     if (context.Request.Path.Value?.Equals("/healthz", StringComparison.OrdinalIgnoreCase) == true)
     {
-        app.Logger.LogInformation("{Method} {Path} {StatusCode}",
-            context.Request.Method,
-            context.Request.Path,
-            context.Response.StatusCode);
+        app.Logger.LogInformation("GET /healthz {StatusCode}", context.Response.StatusCode);
     }
 });
 

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -135,14 +135,15 @@ app.Use(async (context, next) =>
     }
 });
 
+app.UseCors("CpnucleoWebClient");
+
 app.UseHealthChecks("/healthz");
 
 app.UseInfrastructure();
 
 app.UseRateLimiter();
 
-app.UseCors("CpnucleoWebClient")
-    .UseAuthentication()
+app.UseAuthentication()
     .UseAuthorization()
     .UseFastEndpoints(c => c.Endpoints.RoutePrefix = "api")
     .UseMiddleware<ElapsedTimeMiddleware>()

--- a/src/WebClient/src/layouts/AppLayout.astro
+++ b/src/WebClient/src/layouts/AppLayout.astro
@@ -49,9 +49,6 @@ const isActive = (href: string) => {
             <span class="block text-xs text-muted">Project hub</span>
           </span>
         </a>
-        <label class="block rounded-2xl border border-line bg-raised px-3 py-2 text-sm text-muted">
-          Search pages or actions
-        </label>
         <nav class="mt-7 space-y-6">
           {groups.map((group) => (
             <section>
@@ -86,12 +83,10 @@ const isActive = (href: string) => {
               </div>
             </details>
             <div>
-              <p class="text-sm font-medium text-muted">Cpnucleo</p>
               <h1 class="text-lg font-semibold">Application hub</h1>
             </div>
             <div class="flex items-center gap-2 text-sm">
               <ThemeToggle />
-              <span class="hidden rounded-full border border-line bg-raised px-3 py-1 text-muted sm:inline-flex">Ready</span>
               <AuthStatus />
             </div>
           </div>

--- a/src/WebClient/src/routes/index.tsx
+++ b/src/WebClient/src/routes/index.tsx
@@ -32,7 +32,6 @@ export default component$(() => {
             <p class="mt-4 max-w-2xl text-base leading-7 text-muted">Use this space to review projects, people, tasks, blockers, calendar items, and service status without digging through setup details first.</p>
             <div class="mt-7 flex flex-wrap gap-3">
               <a class="rounded-xl bg-ink px-5 py-3 text-sm font-semibold text-canvas shadow-soft transition hover:opacity-90" href="/projects/">Open projects</a>
-              <a class="rounded-xl border border-line bg-raised px-5 py-3 text-sm font-semibold transition hover:border-accent/40 hover:text-accent" href="/api-health/">Check service status</a>
             </div>
           </div>
           <div class="rounded-[1.5rem] border border-line bg-raised p-5">

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -398,7 +398,7 @@ public class FastEndpointsConfigurationTests
         foreach (var program in new[] { apiProgram, identityProgram, grpcProgram })
         {
             program.Should().Contain("context.Request.Path.Value?.Equals(\"/healthz\", StringComparison.OrdinalIgnoreCase) == true");
-            program.Should().Contain("app.Logger.LogInformation(\"{Method} {Path} {StatusCode}\"");
+            program.Should().Contain("app.Logger.LogInformation(\"GET /healthz {StatusCode}\", context.Response.StatusCode)");
         }
 
         apiDockerfile.Should().Contain("HEALTHCHECK --interval=10m");

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -104,6 +104,7 @@ public class FastEndpointsConfigurationTests
     {
         var program = File.ReadAllText(GetRepositoryPath(programPath));
         var useCorsIndex = program.IndexOf("UseCors(\"CpnucleoWebClient\")", StringComparison.Ordinal);
+        var useHealthChecksIndex = program.IndexOf("UseHealthChecks(\"/healthz\")", StringComparison.Ordinal);
         var useAuthenticationIndex = program.IndexOf("UseAuthentication()", StringComparison.Ordinal);
 
         program.Should().Contain("AddCors(options =>");
@@ -114,6 +115,7 @@ public class FastEndpointsConfigurationTests
         program.Should().Contain("AllowAnyMethod()");
         program.Should().Contain("UseRateLimiter()");
         useCorsIndex.Should().BeGreaterThanOrEqualTo(0);
+        useHealthChecksIndex.Should().BeGreaterThan(useCorsIndex, "browser-run health checks call /healthz across subdomains and need CORS headers");
         useAuthenticationIndex.Should().BeGreaterThan(useCorsIndex, "CORS middleware must run before authentication/authorization so browser preflights are answered");
     }
 

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -378,6 +378,9 @@ public class FastEndpointsConfigurationTests
     {
         var compose = File.ReadAllText(GetRepositoryPath("compose.yaml"));
         var prodCompose = File.ReadAllText(GetRepositoryPath("compose.prod.yaml"));
+        var apiProgram = File.ReadAllText(GetRepositoryPath("src/WebApi/Program.cs"));
+        var identityProgram = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Program.cs"));
+        var grpcProgram = File.ReadAllText(GetRepositoryPath("src/GrpcServer/Program.cs"));
         var apiDockerfile = File.ReadAllText(GetRepositoryPath("src/WebApi/Dockerfile"));
         var identityDockerfile = File.ReadAllText(GetRepositoryPath("src/IdentityApi/Dockerfile"));
         var grpcDockerfile = File.ReadAllText(GetRepositoryPath("src/GrpcServer/Dockerfile"));
@@ -391,6 +394,12 @@ public class FastEndpointsConfigurationTests
         prodCompose.Should().Contain("start_interval: 10s");
         compose.Should().Contain("/healthz");
         prodCompose.Should().Contain("/healthz");
+
+        foreach (var program in new[] { apiProgram, identityProgram, grpcProgram })
+        {
+            program.Should().Contain("context.Request.Path.Value?.Equals(\"/healthz\", StringComparison.OrdinalIgnoreCase) == true");
+            program.Should().Contain("app.Logger.LogInformation(\"{Method} {Path} {StatusCode}\"");
+        }
 
         apiDockerfile.Should().Contain("HEALTHCHECK --interval=10m");
         apiDockerfile.Should().Contain("GET /healthz HTTP/1.1");


### PR DESCRIPTION
## Summary
- Add explicit `/healthz` response logging to WebApi, IdentityApi, and GrpcServer so Docker health pings appear in Grafana/Loki alongside the WebClient checks.
- Keep the health-check log message CodeQL-safe by logging a constant route (`GET /healthz`) plus the response status code, rather than request-derived method/path values.
- Run WebApi and IdentityApi CORS middleware before `/healthz` so the WebClient service-health page can fetch cross-subdomain health checks from the browser.
- Extend the architecture guard to require both the 10-minute container health-check configuration, the matching .NET health-check log entry, and browser-safe health-check CORS ordering.
- Simplify the WebClient chrome by removing placeholder/status copy that duplicated the dedicated service-status experience.

## Verification
- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore`
- `dotnet build cpnucleo.slnx --no-restore`
- Production diagnosis: direct `/healthz` responses are healthy, but browser fetches failed because the current deployment does not emit `Access-Control-Allow-Origin` on `/healthz` responses.