### PR TITLE
Fix login brand initials and listing load state

### DIFF
--- a/src/WebClient/src/lib/api/webapi-client.test.ts
+++ b/src/WebClient/src/lib/api/webapi-client.test.ts
@@ -9,6 +9,21 @@ const sseResponse = (payload: unknown) => new Response(
 
 afterEach(() => vi.restoreAllMocks());
 
+const waitForExpectation = async (assertion: () => void) => {
+  const startedAt = Date.now();
+  let lastError: unknown;
+  while (Date.now() - startedAt < 1000) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError;
+};
+
 describe('webapi client', () => {
   it('normalizes array and paginated list payloads', () => {
     expect(normalizeList([{ id: '1' }]).totalCount).toBe(1);
@@ -53,7 +68,7 @@ describe('webapi client', () => {
     const client = createWebApiClient('http://example.test/api');
     const onPage = vi.fn();
     void client.subscribeList('projects', 1, 5, onPage).catch(() => undefined);
-    await vi.waitFor(() => expect(onPage).toHaveBeenCalledWith(expect.objectContaining({ totalCount: 7, items: [{ id: 'seed' }] })));
+    await waitForExpectation(() => expect(onPage).toHaveBeenCalledWith(expect.objectContaining({ totalCount: 7, items: [{ id: 'seed' }] })));
   });
 
   it('fails closed when the subscription response is not an SSE stream', async () => {

--- a/src/WebClient/src/lib/api/webapi-client.test.ts
+++ b/src/WebClient/src/lib/api/webapi-client.test.ts
@@ -19,8 +19,8 @@ describe('webapi client', () => {
     expect(parseServerSentEventData('event: listing\ndata: {"ok":true}\n\n')).toEqual(['{"ok":true}']);
   });
 
-  it('uses plural list and singular item endpoints', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse([]));
+  it('uses paginated JSON lists and singular item endpoints', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }));
     const client = createWebApiClient('http://example.test/api');
     await client.list('projects', 2, 10);
     const listUrl = new URL(fetchMock.mock.calls[0][0]?.toString() ?? '');
@@ -29,7 +29,7 @@ describe('webapi client', () => {
     expect(listUrl.searchParams.get('pageSize')).toBe('10');
     expect(listUrl.searchParams.get('pagination.pageNumber')).toBe('2');
     expect(listUrl.searchParams.get('pagination.pageSize')).toBe('10');
-    expect(new Headers((fetchMock.mock.calls[0][1] as RequestInit).headers).get('Accept')).toBe('text/event-stream');
+    expect(new Headers((fetchMock.mock.calls[0][1] as RequestInit).headers).get('Accept')).toBe('application/json');
     fetchMock.mockResolvedValue(new Response(JSON.stringify({ id: 'abc' }), { status: 200 }));
     await client.update('projects', 'abc', { name: 'Demo' });
     expect(fetchMock.mock.calls[1][0]?.toString()).toBe('http://example.test/api/project?id=abc');
@@ -37,29 +37,47 @@ describe('webapi client', () => {
   });
 
   it('notifies subscribers for streamed list pages', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse({ result: { data: [{ id: '1' }], totalCount: 3, pageNumber: 1, pageSize: 1 } }));
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ result: { data: [], totalCount: 0, pageNumber: 1, pageSize: 1 } }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(sseResponse({ result: { data: [{ id: '1' }], totalCount: 3, pageNumber: 1, pageSize: 1 } }));
     const client = createWebApiClient('http://example.test/api');
     const onPage = vi.fn();
     await client.subscribeList('projects', 1, 1, onPage);
     expect(onPage).toHaveBeenCalledWith(expect.objectContaining({ totalCount: 3, items: [{ id: '1' }] }));
   });
 
-  it('fails closed when the list response is not an SSE stream', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  it('seeds subscribers from the paged JSON endpoint before waiting for live SSE updates', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ result: { data: [{ id: 'seed' }], totalCount: 7, pageNumber: 1, pageSize: 5 } }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockReturnValueOnce(new Promise(() => undefined));
     const client = createWebApiClient('http://example.test/api');
-    await expect(client.list('projects')).rejects.toMatchObject({ name: 'ApiError', message: 'The server did not open a listing stream.' });
+    const onPage = vi.fn();
+    void client.subscribeList('projects', 1, 5, onPage).catch(() => undefined);
+    await vi.waitFor(() => expect(onPage).toHaveBeenCalledWith(expect.objectContaining({ totalCount: 7, items: [{ id: 'seed' }] })));
+  });
+
+  it('fails closed when the subscription response is not an SSE stream', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const client = createWebApiClient('http://example.test/api');
+    await expect(client.subscribeList('projects', 1, 25, () => undefined)).rejects.toMatchObject({ name: 'ApiError', message: 'The server did not open a listing stream.' });
   });
 
   it('fails closed when the SSE stream ends before data arrives', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response('', { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
     const client = createWebApiClient('http://example.test/api');
-    await expect(client.list('projects')).rejects.toMatchObject({ name: 'ApiError', message: 'The listing stream ended before sending data.' });
+    await expect(client.subscribeList('projects', 1, 25, () => undefined)).rejects.toMatchObject({ name: 'ApiError', message: 'The listing stream ended before sending data.' });
   });
 
   it('normalizes malformed SSE payloads as API errors', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('event: listing\ndata: {nope}\n\n', { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response('event: listing\ndata: {nope}\n\n', { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
     const client = createWebApiClient('http://example.test/api');
-    await expect(client.list('projects')).rejects.toMatchObject({ name: 'ApiError', status: 0 });
+    await expect(client.subscribeList('projects', 1, 25, () => undefined)).rejects.toMatchObject({ name: 'ApiError', status: 0 });
   });
 
   it('normalizes API errors', async () => {

--- a/src/WebClient/src/lib/api/webapi-client.ts
+++ b/src/WebClient/src/lib/api/webapi-client.ts
@@ -147,12 +147,14 @@ export const createWebApiClient = (baseUrl = WEBAPI_BASE_URL) => {
     async list<T extends ApiEntity>(resourceKey: ResourceKey, pageNumber = 1, pageSize = 25, signal?: AbortSignal) {
       const resource = findResource(resourceKey);
       const url = withQuery(`${root}${resource.listPath}`, paginationParams(pageNumber, pageSize));
-      const page = await streamList<T>(url, () => undefined, signal, true);
-      return page;
+      const payload = await requestJson<ListEnvelope<T>>(url, { signal });
+      return normalizeList<T>(payload);
     },
     async subscribeList<T extends ApiEntity>(resourceKey: ResourceKey, pageNumber: number, pageSize: number, onPage: ListSubscriber<T>, signal?: AbortSignal) {
       const resource = findResource(resourceKey);
-      await streamList<T>(withQuery(`${root}${resource.listPath}`, paginationParams(pageNumber, pageSize)), onPage, signal);
+      const url = withQuery(`${root}${resource.listPath}`, paginationParams(pageNumber, pageSize));
+      onPage(normalizeList<T>(await requestJson<ListEnvelope<T>>(url, { signal })));
+      await streamList<T>(url, onPage, signal);
     },
     async get<T extends ApiEntity>(resourceKey: ResourceKey, id: string, signal?: AbortSignal) {
       const resource = findResource(resourceKey);

--- a/src/WebClient/src/lib/config.test.ts
+++ b/src/WebClient/src/lib/config.test.ts
@@ -10,7 +10,7 @@ const clearPublicServiceEnv = () => {
 
 const importConfigWithPublicEnvCleared = async () => {
   clearPublicServiceEnv();
-  return import(`./config?defaults=${Date.now()}-${Math.random()}`);
+  return import(`./config?defaults=${Date.now()}-${Math.random().toString(36).slice(2)}`);
 };
 
 describe('public service URLs', () => {

--- a/src/WebClient/src/pages/login.astro
+++ b/src/WebClient/src/pages/login.astro
@@ -29,7 +29,7 @@ import Page from '../routes/login/index';
         <section class="flex flex-col justify-between py-4 lg:py-8">
           <div class="flex items-center justify-between">
             <a href="/" class="flex items-center gap-3">
-              <span class="flex h-11 w-11 items-center justify-center rounded-2xl bg-accent text-sm font-bold text-canvas shadow-soft">Cn</span>
+              <span class="flex h-11 w-11 items-center justify-center rounded-2xl bg-accent text-sm font-bold text-canvas shadow-soft">JP</span>
               <span>
                 <span class="block text-base font-semibold">Cpnucleo</span>
                 <span class="block text-xs text-muted">Operations workspace</span>


### PR DESCRIPTION
## Summary
- change the login page brand initials from Cn to JP
- seed list pages from the existing paginated JSON endpoint before opening the live SSE stream
- keep home counters on the paginated list API so they resolve without waiting on a live stream
- make the config test cache-busting import query safe for the local Vite/esbuild runner

## Verification
- bun run test
- bun run typecheck
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated list subscription handling to fetch initial data via JSON request before streaming subsequent updates.

* **Style**
  * Updated login page avatar text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->