### PR TITLE
Fix listing pagination and SSE fallback

### DIFF
--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -2,6 +2,7 @@ import { $, component$, useSignal, useStore, useVisibleTask$ } from '@builder.io
 import { formFields, tableFields } from '~/lib/api/resource-metadata';
 import { webApiClient } from '~/lib/api/webapi-client';
 import type { ApiEntity, ResourceKey, ResourceMetadata } from '~/lib/api/types';
+import { buildPageOptions, getLastPage } from './pagination';
 
 const formatValue = (value: unknown): string => {
   if (value === null || value === undefined || value === '') return '—';
@@ -39,7 +40,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
 
     void webApiClient.subscribeList(resource.key, page.value, pageSize.value, (result) => {
       const nextTotal = result.totalCount ?? result.items?.length ?? 0;
-      const lastPage = Math.max(1, Math.ceil(nextTotal / pageSize.value));
+      const lastPage = getLastPage(nextTotal, pageSize.value);
       if (page.value > lastPage) {
         page.value = lastPage;
         return;
@@ -99,7 +100,12 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
   });
 
   const previousPage = $(() => { if (page.value > 1) page.value -= 1; });
-  const nextPage = $(() => { if (page.value * pageSize.value < total.value) page.value += 1; });
+  const nextPage = $(() => { if (page.value < getLastPage(total.value, pageSize.value)) page.value += 1; });
+  const goToPage = $((nextPageNumber: number) => { page.value = Math.min(Math.max(1, nextPageNumber), getLastPage(total.value, pageSize.value)); });
+  const changePageSize = $((_event: Event, currentTarget: HTMLSelectElement) => {
+    pageSize.value = Number(currentTarget.value);
+    page.value = 1;
+  });
 
   return (
     <section class="space-y-6">
@@ -149,11 +155,30 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
       )}
 
       <div class="overflow-hidden rounded-xl border border-line bg-surface shadow-soft">
-        <div class="flex flex-col gap-3 border-b border-line px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-          <p class="text-sm text-muted">{total.value} records · page {page.value} of {Math.max(1, Math.ceil(total.value / pageSize.value))}</p>
-          <div class="flex items-center gap-2">
+        <div class="flex flex-col gap-3 border-b border-line px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+          <p class="text-sm text-muted">{total.value} records · page {page.value} of {getLastPage(total.value, pageSize.value)}</p>
+          <div class="flex flex-wrap items-center gap-2">
+            <label class="flex items-center gap-2 text-sm text-muted">
+              Rows
+              <select class="rounded-md border border-line bg-raised px-2 py-2 text-sm text-ink" value={pageSize.value} onChange$={changePageSize}>
+                {[10, 25, 50, 100].map((size) => <option key={String(size)} value={String(size)}>{String(size)}</option>)}
+              </select>
+            </label>
             <button class="rounded-md border border-line px-3 py-2 text-sm disabled:opacity-50" onClick$={previousPage} disabled={page.value <= 1}>Previous</button>
-            <button class="rounded-md border border-line px-3 py-2 text-sm disabled:opacity-50" onClick$={nextPage} disabled={page.value * pageSize.value >= total.value}>Next</button>
+            <div class="flex flex-wrap items-center gap-1" aria-label={`${resource.label} pages`}>
+              {buildPageOptions(total.value, pageSize.value).map((pageNumber) => (
+                <button
+                  key={pageNumber}
+                  type="button"
+                  class={`min-w-10 rounded-md border px-3 py-2 text-sm ${page.value === pageNumber ? 'border-accent bg-accent text-canvas' : 'border-line'}`}
+                  aria-current={page.value === pageNumber ? 'page' : undefined}
+                  onClick$={() => goToPage(pageNumber)}
+                >
+                  {pageNumber}
+                </button>
+              ))}
+            </div>
+            <button class="rounded-md border border-line px-3 py-2 text-sm disabled:opacity-50" onClick$={nextPage} disabled={page.value >= getLastPage(total.value, pageSize.value)}>Next</button>
             <button class="rounded-md border border-line px-3 py-2 text-sm" onClick$={refresh}>Refresh</button>
           </div>
         </div>

--- a/src/WebClient/src/features/crud/pagination.test.ts
+++ b/src/WebClient/src/features/crud/pagination.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildPageOptions, getLastPage } from './pagination';
+
+describe('CRUD pagination helpers', () => {
+  it('builds server-side page options from total count and page size', () => {
+    expect(getLastPage(52, 25)).toBe(3);
+    expect(buildPageOptions(52, 25)).toEqual([1, 2, 3]);
+  });
+
+  it('keeps pagination stable for empty totals and invalid page sizes', () => {
+    expect(getLastPage(0, 25)).toBe(1);
+    expect(buildPageOptions(3, 0)).toEqual([1, 2, 3]);
+  });
+});

--- a/src/WebClient/src/features/crud/pagination.ts
+++ b/src/WebClient/src/features/crud/pagination.ts
@@ -1,0 +1,7 @@
+export const normalizePageSize = (pageSize: number) => Math.max(1, Math.trunc(pageSize) || 1);
+
+export const getLastPage = (totalCount: number, pageSize: number) =>
+  Math.max(1, Math.ceil(Math.max(0, totalCount) / normalizePageSize(pageSize)));
+
+export const buildPageOptions = (totalCount: number, pageSize: number) =>
+  Array.from({ length: getLastPage(totalCount, pageSize) }, (_, index) => index + 1);

--- a/src/WebClient/src/lib/api/webapi-client.test.ts
+++ b/src/WebClient/src/lib/api/webapi-client.test.ts
@@ -71,12 +71,14 @@ describe('webapi client', () => {
     await waitForExpectation(() => expect(onPage).toHaveBeenCalledWith(expect.objectContaining({ totalCount: 7, items: [{ id: 'seed' }] })));
   });
 
-  it('fails closed when the subscription response is not an SSE stream', async () => {
+  it('keeps the seeded page when the server does not open an SSE stream', async () => {
     vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ result: { data: [{ id: 'seed' }], totalCount: 1, pageNumber: 1, pageSize: 25 } }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }));
     const client = createWebApiClient('http://example.test/api');
-    await expect(client.subscribeList('projects', 1, 25, () => undefined)).rejects.toMatchObject({ name: 'ApiError', message: 'The server did not open a listing stream.' });
+    const onPage = vi.fn();
+    await expect(client.subscribeList('projects', 1, 25, onPage)).resolves.toBeUndefined();
+    expect(onPage).toHaveBeenCalledWith(expect.objectContaining({ totalCount: 1, items: [{ id: 'seed' }] }));
   });
 
   it('fails closed when the SSE stream ends before data arrives', async () => {

--- a/src/WebClient/src/lib/api/webapi-client.ts
+++ b/src/WebClient/src/lib/api/webapi-client.ts
@@ -57,7 +57,7 @@ const toApiError = (error: unknown) => {
 const parseListPage = <T extends ApiEntity>(data: string): PaginatedResult<T> =>
   normalizeList<T>(JSON.parse(data) as ListEnvelope<T>);
 
-const streamList = async <T extends ApiEntity>(url: string, onPage: ListSubscriber<T>, signal?: AbortSignal, stopAfterFirst = false): Promise<PaginatedResult<T>> => {
+const streamList = async <T extends ApiEntity>(url: string, onPage: ListSubscriber<T>, signal?: AbortSignal, stopAfterFirst = false): Promise<PaginatedResult<T> | undefined> => {
   throwIfAborted(signal);
 
   const headers = new Headers({ Accept: 'text/event-stream' });
@@ -73,10 +73,8 @@ const streamList = async <T extends ApiEntity>(url: string, onPage: ListSubscrib
   }
 
   if (!response.ok) throw new ApiError(response.status, `Request failed with status ${response.status}.`);
-  if (!response.headers.get('Content-Type')?.toLowerCase().includes('text/event-stream')) {
-    throw new ApiError(0, 'The server did not open a listing stream.');
-  }
-  if (!response.body) throw new ApiError(0, 'The server did not open a listing stream.');
+  if (!response.headers.get('Content-Type')?.toLowerCase().includes('text/event-stream')) return undefined;
+  if (!response.body) return undefined;
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder();


### PR DESCRIPTION
## Summary
- Add explicit server-side grid pagination controls on CRUD listing pages, including page-number buttons and row-count selection.
- Keep pagination state bounded by the server-reported total/page size.
- Stop surfacing `The server did not open a listing stream` after the page has already been seeded from the paginated JSON endpoint; non-SSE responses now leave the paged listing visible instead of failing the screen.

## Verification
- `bun test`
- `bun run test`
- `bun run typecheck`
- `bun run build`