### PR TITLE
Start CRUD lists with server pagination

### DIFF
--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -2,7 +2,7 @@ import { $, component$, useSignal, useStore, useVisibleTask$ } from '@builder.io
 import { formFields, tableFields } from '~/lib/api/resource-metadata';
 import { webApiClient } from '~/lib/api/webapi-client';
 import type { ApiEntity, ResourceKey, ResourceMetadata } from '~/lib/api/types';
-import { buildPageOptions, getLastPage } from './pagination';
+import { buildPageOptions, DEFAULT_PAGE_SIZE, getLastPage } from './pagination';
 
 const formatValue = (value: unknown): string => {
   if (value === null || value === undefined || value === '') return '—';
@@ -22,7 +22,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
   const selected = useSignal<ApiEntity | null>(null);
   const details = useSignal<ApiEntity | null>(null);
   const page = useSignal(1);
-  const pageSize = useSignal(25);
+  const pageSize = useSignal(DEFAULT_PAGE_SIZE);
   const total = useSignal(0);
   const refreshKey = useSignal(0);
 

--- a/src/WebClient/src/features/crud/pagination.test.ts
+++ b/src/WebClient/src/features/crud/pagination.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { buildPageOptions, getLastPage } from './pagination';
+import { buildPageOptions, DEFAULT_PAGE_SIZE, getLastPage } from './pagination';
 
 describe('CRUD pagination helpers', () => {
   it('builds server-side page options from total count and page size', () => {
     expect(getLastPage(52, 25)).toBe(3);
     expect(buildPageOptions(52, 25)).toEqual([1, 2, 3]);
+  });
+
+  it('uses the server-side default page size for initial listing loads', () => {
+    expect(DEFAULT_PAGE_SIZE).toBe(10);
   });
 
   it('keeps pagination stable for empty totals and invalid page sizes', () => {

--- a/src/WebClient/src/features/crud/pagination.ts
+++ b/src/WebClient/src/features/crud/pagination.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_PAGE_SIZE = 10;
+
 export const normalizePageSize = (pageSize: number) => Math.max(1, Math.trunc(pageSize) || 1);
 
 export const getLastPage = (totalCount: number, pageSize: number) =>


### PR DESCRIPTION
## Summary
- Start CRUD listing pages with the server-side default page size of 10 rows.
- Reuse a shared default page-size constant for the initial listing request and row-count UI.
- Add regression coverage so initial listing pages stay paginated by default.

## Verification
- bun test src/features/crud/pagination.test.ts
- bun test src/lib/api/webapi-client.test.ts
- bun test
- bun run typecheck
- bun run build
- dotnet test tests/Architecture.Tests/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Standardized default pagination size to 10 rows per page throughout the CRUD interface.

* **Tests**
  * Added test verification for the default pagination size on initial page load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->