### PR TITLE
Seed fake data after cleaning database

### DIFF
--- a/src/Infrastructure/Common/Helpers/FakeData.cs
+++ b/src/Infrastructure/Common/Helpers/FakeData.cs
@@ -2,6 +2,11 @@ namespace Infrastructure.Common.Helpers;
 
 internal static class FakeDataHelper
 {
+    private const string DefaultDemoLogin = "demo@cpnucleo.local";
+    private const string DefaultDemoPassword = "CpnucleoDemo2026!";
+    private const string DefaultDemoName = "Cpnucleo Demo";
+    private static readonly Guid DefaultDemoUserId = Guid.Parse("0198a4a8-6d1f-7a54-9b1c-c9c430f2d001");
+
     private static List<Appointment>? Appointments { get; set; }
     private static List<AssignmentImpediment>? AssignmentImpediments { get; set; }
     private static List<Assignment>? Assignments { get; set; }
@@ -19,6 +24,8 @@ internal static class FakeDataHelper
         var random = new Random();
         var sb = new StringBuilder();
         var fakeUserPasswordHash = new Argon2PasswordHasher().Hash("FakeUser@123");
+        var defaultDemoPasswordHash = new Argon2PasswordHasher().Hash(DefaultDemoPassword);
+        AppendDatabaseResetAndDefaultUserSql(sb, defaultDemoPasswordHash);
         
         var organizationFaker = new Faker<Organization>()
             .RuleFor(c => c.Id, f => BaseEntity.GetNewId())
@@ -300,8 +307,10 @@ internal static class FakeDataHelper
     {
         var sb = new StringBuilder();
         var fakeUserPasswordHash = new Argon2PasswordHasher().Hash("FakeUser@123");
+        var defaultDemoPasswordHash = new Argon2PasswordHasher().Hash(DefaultDemoPassword);
 
         Directory.CreateDirectory("dml-data");
+        AppendDatabaseResetAndDefaultUserSql(sb, defaultDemoPasswordHash);
 
         var organizationFaker = new Faker<Organization>()
             .RuleFor(c => c.Id, f => BaseEntity.GetNewId())
@@ -580,6 +589,40 @@ internal static class FakeDataHelper
         const string filePath = "003-database-dump-csv-dml.sql";
         File.WriteAllText(filePath, sb.ToString());
     }
+
+    private static void AppendDatabaseResetAndDefaultUserSql(StringBuilder sb, PasswordHash defaultDemoPasswordHash)
+    {
+        sb.AppendLine($"""
+                      TRUNCATE TABLE
+                          "Appointments",
+                          "AssignmentImpediments",
+                          "UserAssignments",
+                          "Assignments",
+                          "UserProjects",
+                          "Projects",
+                          "Organizations",
+                          "Workflows",
+                          "AssignmentTypes",
+                          "Impediments"
+                      RESTART IDENTITY CASCADE;
+
+                      DELETE FROM "Users" WHERE "Login" <> '{DefaultDemoLogin}';
+
+                      INSERT INTO "Users" ("Id", "Name", "Login", "Password", "Salt", "CreatedAt", "UpdatedAt", "DeletedAt", "Active")
+                      SELECT '{DefaultDemoUserId}'::UUID, '{EscapeSqlField(DefaultDemoName)}', '{DefaultDemoLogin}', '{EscapeSqlField(defaultDemoPasswordHash.Hash)}', '{EscapeSqlField(defaultDemoPasswordHash.Salt)}', NOW(), NULL, NULL, true
+                      WHERE NOT EXISTS (SELECT 1 FROM "Users" WHERE "Login" = '{DefaultDemoLogin}');
+
+                      UPDATE "Users"
+                      SET "Name" = '{EscapeSqlField(DefaultDemoName)}',
+                          "Password" = '{EscapeSqlField(defaultDemoPasswordHash.Hash)}',
+                          "Salt" = '{EscapeSqlField(defaultDemoPasswordHash.Salt)}',
+                          "DeletedAt" = NULL,
+                          "Active" = true
+                      WHERE "Login" = '{DefaultDemoLogin}';
+                      """);
+    }
+
+    private static string EscapeSqlField(string value) => value.Replace("'", "''");
 
     private static string EscapeCsvField(string value)
     {

--- a/tests/Architecture.Tests/FakeDataSeedingTests.cs
+++ b/tests/Architecture.Tests/FakeDataSeedingTests.cs
@@ -1,0 +1,53 @@
+namespace Architecture.Tests;
+
+public class FakeDataSeedingTests
+{
+    [Fact]
+    public void FakeDataSeed_ShouldPreserveLoginPageDemoUserAndCleanExistingData()
+    {
+        var fakeData = File.ReadAllText(GetRepositoryPath("src/Infrastructure/Common/Helpers/FakeData.cs"));
+        var loginForm = File.ReadAllText(GetRepositoryPath("src/WebClient/src/routes/login/login-form.ts"));
+
+        loginForm.Should().Contain("DEMO_LOGIN = 'demo@cpnucleo.local'");
+        loginForm.Should().Contain("DEMO_PASSWORD = 'CpnucleoDemo2026!'");
+        fakeData.Should().Contain("DefaultDemoLogin = \"demo@cpnucleo.local\"");
+        fakeData.Should().Contain("DefaultDemoPassword = \"CpnucleoDemo2026!\"");
+        fakeData.Should().Contain("AppendDatabaseResetAndDefaultUserSql(sb, defaultDemoPasswordHash)");
+        fakeData.Should().Contain("DELETE FROM \"Users\" WHERE \"Login\" <> '{DefaultDemoLogin}'");
+        fakeData.Should().Contain("WHERE NOT EXISTS (SELECT 1 FROM \"Users\" WHERE \"Login\" = '{DefaultDemoLogin}')");
+    }
+
+    [Fact]
+    public void FakeDataSeed_ShouldCleanDependentTablesBeforeCopyingNewFakeRows()
+    {
+        var fakeData = File.ReadAllText(GetRepositoryPath("src/Infrastructure/Common/Helpers/FakeData.cs"));
+        var resetIndex = fakeData.IndexOf("AppendDatabaseResetAndDefaultUserSql(sb, defaultDemoPasswordHash)", StringComparison.Ordinal);
+        var firstCopyIndex = fakeData.IndexOf("COPY \"Organizations\"", StringComparison.Ordinal);
+
+        resetIndex.Should().BeGreaterThanOrEqualTo(0);
+        firstCopyIndex.Should().BeGreaterThan(resetIndex, "the database must be cleaned before fake seed rows are copied");
+        fakeData.Should().Contain("TRUNCATE TABLE");
+        fakeData.Should().Contain("\"Appointments\"");
+        fakeData.Should().Contain("\"AssignmentImpediments\"");
+        fakeData.Should().Contain("\"UserAssignments\"");
+        fakeData.Should().Contain("\"Assignments\"");
+        fakeData.Should().Contain("\"UserProjects\"");
+        fakeData.Should().Contain("\"Projects\"");
+        fakeData.Should().Contain("\"Organizations\"");
+        fakeData.Should().Contain("\"Workflows\"");
+        fakeData.Should().Contain("\"AssignmentTypes\"");
+        fakeData.Should().Contain("\"Impediments\"");
+    }
+
+    private static string GetRepositoryPath(string relativePath)
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null && !File.Exists(Path.Combine(currentDirectory.FullName, "cpnucleo.slnx")))
+        {
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        currentDirectory.Should().NotBeNull("tests should run inside the repository checkout");
+        return Path.Combine(currentDirectory!.FullName, relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- prepend FakeData-generated seed dumps with DB cleanup for all listing/domain tables
- preserve/recreate the default demo login user used by the WebClient login page
- add architecture coverage that ties fake seed reset behavior to the login-page demo credentials

## Verification
- dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore
- dotnet test tests/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj --no-restore
- dotnet build src/WebApi/WebApi.csproj --no-restore
- dotnet build src/Infrastructure/Infrastructure.csproj --no-restore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test suite to verify demo data seeding behavior, including validation that demo user credentials are preserved and non-demo users are properly cleaned during database resets.

* **Chores**
  * Standardized demo user credential definitions and refactored database reset logic to ensure consistent database cleanup and default user initialization across seeding operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->