### PR TITLE
ci: retry healthcheck curl transport failures

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -136,9 +136,9 @@ jobs:
       - name: Test Healthcheck Endpoint
         run: |
           for i in {1..20}; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${{ matrix.port }}/healthz)
+            STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 http://localhost:${{ matrix.port }}/healthz) || STATUS=000
             echo "Attempt $i: Status $STATUS"
-            if [ "$STATUS" -eq 200 ]; then
+            if [ "$STATUS" = "200" ]; then
               echo "Healthcheck passed with status $STATUS"
               exit 0
             else

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -243,9 +243,9 @@ jobs:
       - name: Test Healthcheck Endpoint
         run: |
           for i in {1..20}; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${{ matrix.port }}/healthz)
+            STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 http://localhost:${{ matrix.port }}/healthz) || STATUS=000
             echo "Attempt $i: Status $STATUS"
-            if [ "$STATUS" -eq 200 ]; then
+            if [ "$STATUS" = "200" ]; then
               echo "Healthcheck passed with status $STATUS"
               exit 0
             else


### PR DESCRIPTION
## Summary
- Make CI container healthcheck curl probes tolerate transient transport failures like connection reset/refused instead of aborting the retry loop under `bash -e`.
- Switch the status comparison to string equality so fallback status `000` is handled safely.

## Root cause
The failed Main Release run aborted on the first WebClient health probe with curl exit code 56 before the retry loop could run. The workflow was using command substitution under `bash -e`, so curl transport errors exited the step immediately even though the loop was intended to retry.

## Test Plan
- [x] Simulated a curl connection failure under `bash -e` and verified the loop continues with `STATUS=000`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced robustness of automated health checks in CI/CD pipelines with improved timeout handling and error detection mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->