### PR TITLE
fix: persist project soft delete state

### DIFF
--- a/src/Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Infrastructure/Repositories/ProjectRepository.cs
@@ -64,7 +64,11 @@ public class ProjectRepository(NpgsqlConnection connection) : IProjectRepository
     {
         const string query = """
                              UPDATE "Projects"
-                             SET "Name" = @Name, "OrganizationId" = @OrganizationId, "UpdatedAt" = @UpdatedAt
+                             SET "Name" = @Name,
+                                 "OrganizationId" = @OrganizationId,
+                                 "UpdatedAt" = @UpdatedAt,
+                                 "DeletedAt" = @DeletedAt,
+                                 "Active" = @Active
                              WHERE "Id" = @Id;
                              """;
 

--- a/src/Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Infrastructure/Repositories/ProjectRepository.cs
@@ -72,7 +72,7 @@ public class ProjectRepository(NpgsqlConnection connection) : IProjectRepository
                              WHERE "Id" = @Id;
                              """;
 
-        var affectedRows = await connection.ExecuteAsync(query, entity);
+        var affectedRows = await connection.ExecuteAsync(query, entity).ConfigureAwait(false);
         return affectedRows > 0;
     }
 

--- a/tests/Architecture.Tests/DapperRepositorySourceTests.cs
+++ b/tests/Architecture.Tests/DapperRepositorySourceTests.cs
@@ -5,6 +5,15 @@ namespace Architecture.Tests;
 public class DapperRepositorySourceTests
 {
     [Fact]
+    public void ProjectRepository_UpdateAsync_Should_Persist_Soft_Delete_Columns()
+    {
+        var projectRepository = File.ReadAllText(GetRepositoryPath("src/Infrastructure/Repositories/ProjectRepository.cs"));
+
+        projectRepository.Should().Contain("\"Active\" = @Active", "Project.Remove uses Active=false and the repository must persist it");
+        projectRepository.Should().Contain("\"DeletedAt\" = @DeletedAt", "soft-deleted projects need a persisted deletion timestamp");
+    }
+
+    [Fact]
     public void DapperRepository_Should_Not_Treat_Navigation_Properties_As_Table_Columns()
     {
         var repositoryType = typeof(Infrastructure.Repositories.DapperRepository<Domain.Entities.Project>);
@@ -15,5 +24,19 @@ public class DapperRepositorySourceTests
 
         columns.Should().Contain("\"OrganizationId\"");
         columns.Should().NotContain("\"Organization\"", "navigation objects are not database columns and break project seeding through the public API");
+    }
+
+    private static string GetRepositoryPath(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "cpnucleo.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the test should run from inside the cpnucleo repository output tree");
+
+        return Path.Combine(directory!.FullName, relativePath);
     }
 }


### PR DESCRIPTION
## Summary
- persist `Active` and `DeletedAt` in `ProjectRepository.UpdateAsync`
- add an architecture regression test proving project soft-delete columns stay in the update SQL

## Test Plan
- [x] `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore --filter ProjectRepository_UpdateAsync_Should_Persist_Soft_Delete_Columns --verbosity minimal`
- [x] `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore --verbosity minimal`
- [x] `dotnet build src/Infrastructure/Infrastructure.csproj --no-restore --verbosity minimal`

Note: local commands emit existing NuGet vulnerability-cache permission warnings, but tests/build pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project update operations to properly persist active status and deletion timestamp fields when modifying project records, ensuring soft-delete data is accurately maintained across all update scenarios.

* **Tests**
  * Added comprehensive verification test to ensure soft-delete field persistence is correctly implemented during project updates and properly maintains data integrity across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->