### PR TITLE
Add canonical production CSV seed import

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -250,6 +250,26 @@ services:
           memory: "512M"
     <<: *common-logging
 
+  seed-csv-cpnucleo:
+    <<: *common-logging
+    image: ${CPNUCLEO_WEB_API_IMAGE:?Set CPNUCLEO_WEB_API_IMAGE to an immutable GHCR tag, not latest}
+    container_name: seed-csv-cpnucleo
+    env_file:
+      - .env
+    command: ["--run-fake-data-csv-import"]
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.00"
+          memory: "2G"
+        reservations:
+          cpus: "0.50"
+          memory: "1G"
+
   # Kept in production as the internal API load balancer, matching local dev topology.
   # Traefik owns public TLS/host routing; NGINX only balances webapi1/webapi2.
   nginx:

--- a/src/Infrastructure/Common/Helpers/ConsoleSeedLogger.cs
+++ b/src/Infrastructure/Common/Helpers/ConsoleSeedLogger.cs
@@ -1,0 +1,27 @@
+namespace Infrastructure.Common.Helpers;
+
+public sealed class ConsoleSeedLogger : ILogger
+{
+    private readonly string _categoryName;
+
+    public ConsoleSeedLogger(string categoryName) => _categoryName = categoryName;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        var timestamp = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+        Console.WriteLine("{0} [{1}] {2}: {3}", timestamp, logLevel, _categoryName, formatter(state, exception));
+        if (exception is not null)
+        {
+            Console.WriteLine(exception);
+        }
+    }
+}

--- a/src/Infrastructure/Common/Helpers/FakeDataCsvImporter.cs
+++ b/src/Infrastructure/Common/Helpers/FakeDataCsvImporter.cs
@@ -1,0 +1,414 @@
+namespace Infrastructure.Common.Helpers;
+
+public static class FakeDataCsvImporter
+{
+    private const string SeedVersion = "fake-data-csv-v1-20260528";
+    private const string DefaultDemoLogin = "demo@cpnucleo.local";
+    private const string DefaultDemoPassword = "CpnucleoDemo2026!";
+    private const string DefaultDemoName = "Cpnucleo Demo";
+    private static readonly Guid DefaultDemoUserId = Guid.Parse("0198a4a8-6d1f-7a54-9b1c-c9c430f2d001");
+
+    private const int OrganizationCount = 686;
+    private const int ProjectCount = 1_258;
+    private const int ImpedimentCount = 114;
+    private const int AssignmentTypeCount = 3;
+    private const int WorkflowCount = 6;
+    private const int UserCount = 11_154;
+    private const int UserProjectCount = 24_400;
+    private const int AssignmentCount = 464_587;
+    private const int UserAssignmentCount = 363_554;
+    private const int AssignmentImpedimentCount = 11_369;
+    private const int AppointmentCount = 489_571;
+
+    public static async Task RunAsync(string connectionString, ILogger logger, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await EnsureSeedHistoryTableAsync(connection, cancellationToken).ConfigureAwait(false);
+        if (await SeedAlreadyAppliedAsync(connection, cancellationToken).ConfigureAwait(false))
+        {
+            logger.LogInformation("Fake CSV seed {SeedVersion} already applied; skipping import.", SeedVersion);
+            return;
+        }
+
+        logger.LogWarning("Starting canonical FakeData CSV import {SeedVersion}; existing demo data will be replaced.", SeedVersion);
+        var startedAt = DateTimeOffset.UtcNow;
+
+        await ResetDatabaseAsync(connection, cancellationToken).ConfigureAwait(false);
+
+        var random = new Random(20260528);
+        Randomizer.Seed = new Random(20260528);
+
+        var passwordHasher = new Argon2PasswordHasher();
+        var fakeUserPasswordHash = passwordHasher.Hash("FakeUser@123");
+        var defaultDemoPasswordHash = passwordHasher.Hash(DefaultDemoPassword);
+
+        var organizationIds = CreateIds(OrganizationCount);
+        var projectIds = CreateIds(ProjectCount);
+        var impedimentIds = CreateIds(ImpedimentCount);
+        var assignmentTypeIds = CreateIds(AssignmentTypeCount);
+        var workflowIds = CreateIds(WorkflowCount);
+        var userIds = CreateIds(UserCount);
+        var assignmentIds = CreateIds(AssignmentCount);
+
+        await ImportOrganizationsAsync(connection, organizationIds, logger, cancellationToken).ConfigureAwait(false);
+        await ImportProjectsAsync(connection, projectIds, organizationIds, logger, cancellationToken).ConfigureAwait(false);
+        await ImportImpedimentsAsync(connection, impedimentIds, logger, cancellationToken).ConfigureAwait(false);
+        await ImportAssignmentTypesAsync(connection, assignmentTypeIds, logger, cancellationToken).ConfigureAwait(false);
+        await ImportWorkflowsAsync(connection, workflowIds, logger, cancellationToken).ConfigureAwait(false);
+        await ImportUsersAsync(connection, userIds, fakeUserPasswordHash, logger, cancellationToken).ConfigureAwait(false);
+        await InsertDefaultDemoUserAsync(connection, defaultDemoPasswordHash, cancellationToken).ConfigureAwait(false);
+        await ImportUserProjectsAsync(connection, userIds, projectIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportAssignmentsAsync(connection, assignmentIds, projectIds, workflowIds, userIds, assignmentTypeIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportUserAssignmentsAsync(connection, userIds, assignmentIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportAssignmentImpedimentsAsync(connection, assignmentIds, impedimentIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportAppointmentsAsync(connection, assignmentIds, userIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await MarkSeedAppliedAsync(connection, startedAt, cancellationToken).ConfigureAwait(false);
+
+        logger.LogWarning(
+            "Finished canonical FakeData CSV import {SeedVersion}: Organizations={OrganizationCount}, Projects={ProjectCount}, Impediments={ImpedimentCount}, AssignmentTypes={AssignmentTypeCount}, Workflows={WorkflowCount}, Users={UserCount}+demo, UserProjects={UserProjectCount}, Assignments={AssignmentCount}, UserAssignments={UserAssignmentCount}, AssignmentImpediments={AssignmentImpedimentCount}, Appointments={AppointmentCount} in {ElapsedSeconds:n1}s.",
+            SeedVersion,
+            OrganizationCount,
+            ProjectCount,
+            ImpedimentCount,
+            AssignmentTypeCount,
+            WorkflowCount,
+            UserCount,
+            UserProjectCount,
+            AssignmentCount,
+            UserAssignmentCount,
+            AssignmentImpedimentCount,
+            AppointmentCount,
+            (DateTimeOffset.UtcNow - startedAt).TotalSeconds);
+    }
+
+    private static async Task EnsureSeedHistoryTableAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        const string sql = """
+                           CREATE TABLE IF NOT EXISTS "__FakeDataCsvImports" (
+                               "Version" text NOT NULL PRIMARY KEY,
+                               "StartedAt" timestamp with time zone NOT NULL,
+                               "CompletedAt" timestamp with time zone NOT NULL
+                           );
+                           """;
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<bool> SeedAlreadyAppliedAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand("SELECT EXISTS (SELECT 1 FROM \"__FakeDataCsvImports\" WHERE \"Version\" = @version);", connection);
+        command.Parameters.AddWithValue("version", SeedVersion);
+        return (bool)(await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) ?? false);
+    }
+
+    private static async Task ResetDatabaseAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        const string sql = """
+                           TRUNCATE TABLE
+                               "Appointments",
+                               "AssignmentImpediments",
+                               "UserAssignments",
+                               "Assignments",
+                               "UserProjects",
+                               "Projects",
+                               "Organizations",
+                               "Workflows",
+                               "AssignmentTypes",
+                               "Impediments",
+                               "Users"
+                           RESTART IDENTITY CASCADE;
+                           """;
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task InsertDefaultDemoUserAsync(NpgsqlConnection connection, PasswordHash defaultDemoPasswordHash, CancellationToken cancellationToken)
+    {
+        const string sql = """
+                           INSERT INTO "Users" ("Id", "Name", "Login", "Password", "Salt", "CreatedAt", "UpdatedAt", "DeletedAt", "Active")
+                           VALUES (@id, @name, @login, @password, @salt, @createdAt, NULL, NULL, TRUE)
+                           ON CONFLICT ("Id") DO UPDATE
+                           SET "Name" = EXCLUDED."Name",
+                               "Login" = EXCLUDED."Login",
+                               "Password" = EXCLUDED."Password",
+                               "Salt" = EXCLUDED."Salt",
+                               "UpdatedAt" = now(),
+                               "DeletedAt" = NULL,
+                               "Active" = TRUE;
+                           """;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("id", DefaultDemoUserId);
+        command.Parameters.AddWithValue("name", DefaultDemoName);
+        command.Parameters.AddWithValue("login", DefaultDemoLogin);
+        command.Parameters.AddWithValue("password", defaultDemoPasswordHash.Hash);
+        command.Parameters.AddWithValue("salt", defaultDemoPasswordHash.Salt);
+        command.Parameters.AddWithValue("createdAt", DateTimeOffset.UtcNow);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task MarkSeedAppliedAsync(NpgsqlConnection connection, DateTimeOffset startedAt, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(
+            "INSERT INTO \"__FakeDataCsvImports\" (\"Version\", \"StartedAt\", \"CompletedAt\") VALUES (@version, @startedAt, @completedAt);",
+            connection);
+        command.Parameters.AddWithValue("version", SeedVersion);
+        command.Parameters.AddWithValue("startedAt", startedAt);
+        command.Parameters.AddWithValue("completedAt", DateTimeOffset.UtcNow);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Guid[] CreateIds(int count)
+    {
+        var ids = new Guid[count];
+        for (var i = 0; i < ids.Length; i++)
+        {
+            ids[i] = BaseEntity.GetNewId();
+        }
+
+        return ids;
+    }
+
+    private static async Task ImportOrganizationsAsync(NpgsqlConnection connection, Guid[] ids, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"Organizations\" (\"Id\", \"Name\", \"Description\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(
+                ids[i],
+                $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
+                faker.Hacker.Phrase(),
+                PastCreatedAt(faker),
+                PastUpdatedAt(faker),
+                active ? null : PastDeletedAt(faker),
+                active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} organizations via CSV COPY.", ids.Length);
+    }
+
+    private static async Task ImportProjectsAsync(NpgsqlConnection connection, Guid[] ids, Guid[] organizationIds, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"Projects\" (\"Id\", \"Name\", \"OrganizationId\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(
+                ids[i],
+                $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
+                faker.PickRandom(organizationIds),
+                PastCreatedAt(faker),
+                PastUpdatedAt(faker),
+                active ? null : PastDeletedAt(faker),
+                active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} projects via CSV COPY.", ids.Length);
+    }
+
+    private static async Task ImportImpedimentsAsync(NpgsqlConnection connection, Guid[] ids, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"Impediments\" (\"Id\", \"Name\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(ids[i], $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}", PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} impediments via CSV COPY.", ids.Length);
+    }
+
+    private static async Task ImportAssignmentTypesAsync(NpgsqlConnection connection, Guid[] ids, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"AssignmentTypes\" (\"Id\", \"Name\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(ids[i], $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}", PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} assignment types via CSV COPY.", ids.Length);
+    }
+
+    private static async Task ImportWorkflowsAsync(NpgsqlConnection connection, Guid[] ids, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"Workflows\" (\"Id\", \"Name\", \"Order\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(ids[i], $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}", i + 1, PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} workflows via CSV COPY.", ids.Length);
+    }
+
+    private static async Task ImportUsersAsync(NpgsqlConnection connection, Guid[] ids, PasswordHash passwordHash, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"Users\" (\"Id\", \"Name\", \"Login\", \"Password\", \"Salt\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(ids[i], faker.Name.FullName(), faker.Internet.UserName(), passwordHash.Hash, passwordHash.Salt, PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} users via CSV COPY.", ids.Length);
+    }
+
+    private static async Task ImportUserProjectsAsync(NpgsqlConnection connection, Guid[] userIds, Guid[] projectIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"UserProjects\" (\"Id\", \"UserId\", \"ProjectId\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < UserProjectCount; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), Pick(userIds, random), Pick(projectIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} user projects via CSV COPY.", UserProjectCount);
+    }
+
+    private static async Task ImportAssignmentsAsync(NpgsqlConnection connection, Guid[] ids, Guid[] projectIds, Guid[] workflowIds, Guid[] userIds, Guid[] assignmentTypeIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"Assignments\" (\"Id\", \"Name\", \"Description\", \"StartDate\", \"EndDate\", \"AmountHours\", \"ProjectId\", \"WorkflowId\", \"UserId\", \"AssignmentTypeId\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(
+                ids[i],
+                $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
+                faker.Hacker.Phrase(),
+                AssignmentStartDate(faker),
+                AssignmentEndDate(faker),
+                faker.Random.Number(12, 60),
+                Pick(projectIds, random),
+                Pick(workflowIds, random),
+                Pick(userIds, random),
+                Pick(assignmentTypeIds, random),
+                PastCreatedAt(faker),
+                PastUpdatedAt(faker),
+                active ? null : PastDeletedAt(faker),
+                active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} assignments via CSV COPY.", ids.Length);
+    }
+
+    private static async Task ImportUserAssignmentsAsync(NpgsqlConnection connection, Guid[] userIds, Guid[] assignmentIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"UserAssignments\" (\"Id\", \"UserId\", \"AssignmentId\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < UserAssignmentCount; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), Pick(userIds, random), Pick(assignmentIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} user assignments via CSV COPY.", UserAssignmentCount);
+    }
+
+    private static async Task ImportAssignmentImpedimentsAsync(NpgsqlConnection connection, Guid[] assignmentIds, Guid[] impedimentIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"AssignmentImpediments\" (\"Id\", \"Description\", \"AssignmentId\", \"ImpedimentId\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < AssignmentImpedimentCount; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), faker.Hacker.Phrase(), Pick(assignmentIds, random), Pick(impedimentIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} assignment impediments via CSV COPY.", AssignmentImpedimentCount);
+    }
+
+    private static async Task ImportAppointmentsAsync(NpgsqlConnection connection, Guid[] assignmentIds, Guid[] userIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    {
+        var faker = new Faker();
+        await using var writer = await connection.BeginTextImportAsync(
+            "COPY \"Appointments\" (\"Id\", \"Description\", \"KeepDate\", \"AmountHours\", \"AssignmentId\", \"UserId\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
+            cancellationToken).ConfigureAwait(false);
+
+        for (var i = 0; i < AppointmentCount; i++)
+        {
+            var active = faker.Random.Bool();
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), faker.Hacker.Phrase(), KeepDate(faker), faker.Random.Number(1, 6), Pick(assignmentIds, random), Pick(userIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} appointments via CSV COPY.", AppointmentCount);
+    }
+
+    private static Guid Pick(Guid[] values, Random random) => values[random.Next(values.Length)];
+
+    private static DateTimeOffset PastCreatedAt(Faker faker) => ToUtc(faker.Date.Between(DateTime.UtcNow.AddMonths(faker.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(faker.Random.Number(-24, -12))));
+
+    private static DateTimeOffset PastUpdatedAt(Faker faker) => ToUtc(faker.Date.Between(DateTime.UtcNow.AddMonths(faker.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(faker.Random.Number(-6, -2))));
+
+    private static DateTimeOffset PastDeletedAt(Faker faker) => ToUtc(faker.Date.Between(DateTime.UtcNow.AddMonths(faker.Random.Number(-11, -7)), DateTime.UtcNow.AddMonths(faker.Random.Number(-7, -6))));
+
+    private static DateTimeOffset AssignmentStartDate(Faker faker) => ToUtc(faker.Date.Between(DateTime.UtcNow.AddMonths(faker.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(faker.Random.Number(-24, -12))));
+
+    private static DateTimeOffset AssignmentEndDate(Faker faker) => ToUtc(faker.Date.Between(DateTime.UtcNow.AddMonths(faker.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(faker.Random.Number(-6, -2))));
+
+    private static DateTimeOffset KeepDate(Faker faker) => ToUtc(faker.Date.Between(DateTime.UtcNow.AddMonths(faker.Random.Number(-11, -9)), DateTime.UtcNow.AddMonths(faker.Random.Number(-8, -6))));
+
+    private static DateTimeOffset ToUtc(DateTime value) => new(DateTime.SpecifyKind(value, DateTimeKind.Utc));
+
+    private static string Csv(params object?[] values) => string.Join(',', values.Select(ToCsvField));
+
+    private static string ToCsvField(object? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        var text = value switch
+        {
+            DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+            bool boolean => boolean.ToString().ToLowerInvariant(),
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty,
+            _ => value.ToString() ?? string.Empty
+        };
+
+        return string.Concat('"', text.Replace("\"", "\"\"", StringComparison.Ordinal), '"');
+    }
+}

--- a/src/Infrastructure/Usings.cs
+++ b/src/Infrastructure/Usings.cs
@@ -1,4 +1,5 @@
 global using System.Collections.Concurrent;
+global using System.Globalization;
 global using System.ComponentModel.DataAnnotations.Schema;
 global using System.Reflection;
 global using System.Text;

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,5 +1,13 @@
 var builder = WebApplication.CreateSlimBuilder(args);
 
+if (args.Contains("--run-fake-data-csv-import", StringComparer.OrdinalIgnoreCase))
+{
+    await FakeDataCsvImporter.RunAsync(
+        builder.Configuration.GetValue<string>("DB_CONNECTION_STRING") ?? throw new InvalidOperationException("DB_CONNECTION_STRING configuration is missing."),
+        new ConsoleSeedLogger("FakeDataCsvImporter"));
+    return;
+}
+
 builder.ConfigureOpenTelemetry();
 
 var allowedCorsOrigins = builder.Configuration

--- a/src/WebApi/Usings.cs
+++ b/src/WebApi/Usings.cs
@@ -17,6 +17,7 @@ global using FastEndpoints.Swagger;
 global using FluentValidation;
 global using Infrastructure;
 global using Infrastructure.Common.Context;
+global using Infrastructure.Common.Helpers;
 global using Microsoft.AspNetCore.Authentication.JwtBearer;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.DependencyInjection;

--- a/tests/Architecture.Tests/FakeDataSeedingTests.cs
+++ b/tests/Architecture.Tests/FakeDataSeedingTests.cs
@@ -39,6 +39,32 @@ public class FakeDataSeedingTests
         fakeData.Should().Contain("\"Impediments\"");
     }
 
+    [Fact]
+    public void ProductionCsvSeeder_ShouldUseCanonicalFakeDataCountsAndOneShotContainer()
+    {
+        var importer = File.ReadAllText(GetRepositoryPath("src/Infrastructure/Common/Helpers/FakeDataCsvImporter.cs"));
+        var program = File.ReadAllText(GetRepositoryPath("src/WebApi/Program.cs"));
+        var compose = File.ReadAllText(GetRepositoryPath("compose.prod.yaml"));
+
+        importer.Should().Contain("private const int OrganizationCount = 686");
+        importer.Should().Contain("private const int ProjectCount = 1_258");
+        importer.Should().Contain("private const int UserCount = 11_154");
+        importer.Should().Contain("private const int AssignmentCount = 464_587");
+        importer.Should().Contain("private const int UserAssignmentCount = 363_554");
+        importer.Should().Contain("private const int AppointmentCount = 489_571");
+        importer.Should().Contain("FROM STDIN WITH (FORMAT CSV)");
+        importer.Should().Contain("__FakeDataCsvImports");
+        importer.Should().Contain("TRUNCATE TABLE");
+        importer.Should().Contain("DefaultDemoLogin = \"demo@cpnucleo.local\"");
+
+        program.Should().Contain("--run-fake-data-csv-import");
+        program.Should().Contain("FakeDataCsvImporter.RunAsync");
+
+        compose.Should().Contain("seed-csv-cpnucleo:");
+        compose.Should().Contain("command: [\"--run-fake-data-csv-import\"]");
+        compose.Should().Contain("restart: \"no\"");
+    }
+
     private static string GetRepositoryPath(string relativePath)
     {
         var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Summary
- add a one-shot WebApi CSV COPY importer for the canonical FakeData volume
- wire a production `seed-csv-cpnucleo` container that runs the importer against the private Docker-network PostgreSQL database
- preserve the demo login and add a seed-history marker so future deploys skip once applied
- add architecture coverage for the canonical counts, CSV COPY path, startup command, and production seeder service

## Test plan
- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore -v minimal`
- `dotnet build src/WebApi/WebApi.csproj -c Release -p:AOT=false -p:Trim=true -p:ExtraOptimize=true --no-restore -v minimal`

Note: local Docker Compose validation could not run because the local Docker CLI does not have the Compose plugin installed.