### PR TITLE
Make canonical CSV seed fully visible

### DIFF
--- a/src/Infrastructure/Common/Helpers/FakeDataCsvImporter.cs
+++ b/src/Infrastructure/Common/Helpers/FakeDataCsvImporter.cs
@@ -2,7 +2,7 @@ namespace Infrastructure.Common.Helpers;
 
 public static class FakeDataCsvImporter
 {
-    private const string SeedVersion = "fake-data-csv-v1-20260528";
+    private const string SeedVersion = "fake-data-csv-v2-20260528-active-visible";
     private const string DefaultDemoLogin = "demo@cpnucleo.local";
     private const string DefaultDemoPassword = "CpnucleoDemo2026!";
     private const string DefaultDemoName = "Cpnucleo Demo";
@@ -181,7 +181,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < ids.Length; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(
                 ids[i],
                 $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
@@ -204,7 +204,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < ids.Length; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(
                 ids[i],
                 $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
@@ -227,7 +227,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < ids.Length; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(ids[i], $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}", PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
@@ -243,7 +243,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < ids.Length; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(ids[i], $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}", PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
@@ -259,7 +259,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < ids.Length; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(ids[i], $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}", i + 1, PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
@@ -275,7 +275,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < ids.Length; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(ids[i], faker.Name.FullName(), faker.Internet.UserName(), passwordHash.Hash, passwordHash.Salt, PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
@@ -291,7 +291,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < UserProjectCount; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), Pick(userIds, random), Pick(projectIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
@@ -307,7 +307,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < ids.Length; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(
                 ids[i],
                 $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
@@ -337,7 +337,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < UserAssignmentCount; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), Pick(userIds, random), Pick(assignmentIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
@@ -353,7 +353,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < AssignmentImpedimentCount; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), faker.Hacker.Phrase(), Pick(assignmentIds, random), Pick(impedimentIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
@@ -369,7 +369,7 @@ public static class FakeDataCsvImporter
 
         for (var i = 0; i < AppointmentCount; i++)
         {
-            var active = faker.Random.Bool();
+            var active = true;
             await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), faker.Hacker.Phrase(), KeepDate(faker), faker.Random.Number(1, 6), Pick(assignmentIds, random), Pick(userIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 

--- a/tests/Architecture.Tests/FakeDataSeedingTests.cs
+++ b/tests/Architecture.Tests/FakeDataSeedingTests.cs
@@ -52,6 +52,7 @@ public class FakeDataSeedingTests
         importer.Should().Contain("private const int AssignmentCount = 464_587");
         importer.Should().Contain("private const int UserAssignmentCount = 363_554");
         importer.Should().Contain("private const int AppointmentCount = 489_571");
+        importer.Should().NotContain("faker.Random.Bool()");
         importer.Should().Contain("FROM STDIN WITH (FORMAT CSV)");
         importer.Should().Contain("__FakeDataCsvImports");
         importer.Should().Contain("TRUNCATE TABLE");


### PR DESCRIPTION
## Summary
- bump the production seed marker so the CSV importer reseeds after the first import
- import all canonical FakeData rows as active so public API/UI counts reflect the hardcoded generation volumes, e.g. 686 organizations rather than roughly half of that
- add regression coverage so the importer does not silently reintroduce random Active flags

## Test plan
- `dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore -v minimal`