### PR TITLE
Scope fake data relationships by tenant

### DIFF
--- a/src/Infrastructure/Common/Helpers/FakeData.cs
+++ b/src/Infrastructure/Common/Helpers/FakeData.cs
@@ -306,6 +306,7 @@ internal static class FakeDataHelper
     internal static void CreateSqlCsvDumpFile()
     {
         var sb = new StringBuilder();
+        var random = new Random();
         var fakeUserPasswordHash = new Argon2PasswordHasher().Hash("FakeUser@123");
         var defaultDemoPasswordHash = new Argon2PasswordHasher().Hash(DefaultDemoPassword);
 
@@ -338,13 +339,19 @@ internal static class FakeDataHelper
         var projectFaker = new Faker<Project>()
             .RuleFor(c => c.Id, f => BaseEntity.GetNewId())
             .RuleFor(x => x.Name, f => $"{f.Hacker.Noun()} {f.Hacker.IngVerb()} {f.Hacker.Adjective()}")
-            .RuleFor(p => p.OrganizationId, f => f.PickRandom(Organizations).Id)
             .RuleFor(o => o.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(f.Random.Number(-24, -12))))
             .RuleFor(o => o.UpdatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(f.Random.Number(-6, -2))))
             .RuleFor(o => o.DeletedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-11, -7)), DateTime.UtcNow.AddMonths(f.Random.Number(-7, -6))))
             .RuleFor(x => x.Active, f => f.Random.Bool());
 
         Projects = projectFaker.Generate(1258);
+        for (var i = 0; i < Projects.Count; i++)
+        {
+            Projects[i].OrganizationId = i < Organizations.Count
+                ? Organizations[i].Id
+                : PickRandom(Organizations, random).Id;
+        }
+
         WriteCsv("Projects.csv", Projects, x =>
         [
             x.Id.ToString(),
@@ -435,6 +442,10 @@ internal static class FakeDataHelper
             .RuleFor(x => x.Active, f => f.Random.Bool());
 
         Users = userFaker.Generate(11154);
+        var userOrganizationIds = Users
+            .Select((user, index) => new { user.Id, OrganizationId = Organizations[index % Organizations.Count].Id })
+            .ToDictionary(x => x.Id, x => x.OrganizationId);
+
         WriteCsv("Users.csv", Users, x =>
         [
             x.Id.ToString(),
@@ -450,16 +461,16 @@ internal static class FakeDataHelper
 
         sb.AppendLine("""COPY "Users" ("Id", "Name", "Login", "Password", "Salt", "CreatedAt", "UpdatedAt", "DeletedAt", "Active") FROM '/docker-entrypoint-initdb.d/dml-data/Users.csv' WITH (FORMAT CSV);""");
 
-        var userProjectFaker = new Faker<UserProject>()
-            .RuleFor(c => c.Id, f => BaseEntity.GetNewId())
-            .RuleFor(up => up.UserId, f => f.PickRandom(Users).Id)
-            .RuleFor(up => up.ProjectId, f => f.PickRandom(Projects).Id)
-            .RuleFor(o => o.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(f.Random.Number(-24, -12))))
-            .RuleFor(o => o.UpdatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(f.Random.Number(-6, -2))))
-            .RuleFor(o => o.DeletedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-11, -7)), DateTime.UtcNow.AddMonths(f.Random.Number(-7, -6))))
-            .RuleFor(x => x.Active, f => f.Random.Bool());
+        UserProjects = Projects
+            .Select(project => UserProject.Create(DefaultDemoUserId, project.Id))
+            .ToList();
 
-        UserProjects = userProjectFaker.Generate(24400);
+        while (UserProjects.Count < 24400)
+        {
+            var user = PickRandom(Users, random);
+            var project = PickProjectForOrganization(Projects, userOrganizationIds[user.Id], random);
+            UserProjects.Add(UserProject.Create(user.Id, project.Id));
+        }
         WriteCsv("UserProjects.csv", UserProjects, x =>
         [
             x.Id.ToString(),
@@ -480,9 +491,7 @@ internal static class FakeDataHelper
             .RuleFor(o => o.StartDate, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(f.Random.Number(-24, -12))))
             .RuleFor(o => o.EndDate, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(f.Random.Number(-6, -2))))
             .RuleFor(x => x.AmountHours, f => f.Random.Number(12, 60))
-            .RuleFor(a => a.ProjectId, f => f.PickRandom(Projects).Id)
             .RuleFor(a => a.WorkflowId, f => f.PickRandom(Workflows).Id)
-            .RuleFor(a => a.UserId, f => f.PickRandom(Users).Id)
             .RuleFor(a => a.AssignmentTypeId, f => f.PickRandom(AssignmentTypes).Id)
             .RuleFor(o => o.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(f.Random.Number(-24, -12))))
             .RuleFor(o => o.UpdatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(f.Random.Number(-6, -2))))
@@ -490,6 +499,16 @@ internal static class FakeDataHelper
             .RuleFor(x => x.Active, f => f.Random.Bool());
 
         Assignments = assignmentFaker.Generate(464587);
+        var assignmentOrganizationIds = new Dictionary<Guid, Guid>(Assignments.Count);
+        foreach (var assignment in Assignments)
+        {
+            var project = PickRandom(Projects, random);
+            var organizationId = project.OrganizationId;
+            assignment.ProjectId = project.Id;
+            assignment.UserId = PickUserForOrganization(Users, userOrganizationIds, organizationId, random).Id;
+            assignmentOrganizationIds[assignment.Id] = organizationId;
+        }
+
         WriteCsv("Assignments.csv", Assignments, x =>
         [
             x.Id.ToString(),
@@ -512,14 +531,19 @@ internal static class FakeDataHelper
 
         var userAssignmentFaker = new Faker<UserAssignment>()
             .RuleFor(c => c.Id, f => BaseEntity.GetNewId())
-            .RuleFor(ua => ua.UserId, f => f.PickRandom(Users).Id)
-            .RuleFor(ua => ua.AssignmentId, f => f.PickRandom(Assignments).Id)
             .RuleFor(o => o.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(f.Random.Number(-24, -12))))
             .RuleFor(o => o.UpdatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(f.Random.Number(-6, -2))))
             .RuleFor(o => o.DeletedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-11, -7)), DateTime.UtcNow.AddMonths(f.Random.Number(-7, -6))))
             .RuleFor(x => x.Active, f => f.Random.Bool());
 
         UserAssignments = userAssignmentFaker.Generate(363554);
+        foreach (var userAssignment in UserAssignments)
+        {
+            var assignment = PickRandom(Assignments, random);
+            userAssignment.AssignmentId = assignment.Id;
+            userAssignment.UserId = PickUserForOrganization(Users, userOrganizationIds, assignmentOrganizationIds[assignment.Id], random).Id;
+        }
+
         WriteCsv("UserAssignments.csv", UserAssignments, x =>
         [
             x.Id.ToString(),
@@ -562,14 +586,19 @@ internal static class FakeDataHelper
             .RuleFor(x => x.Description, f => f.Hacker.Phrase())
             .RuleFor(o => o.KeepDate, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-11, -9)), DateTime.UtcNow.AddMonths(f.Random.Number(-8, -6))))
             .RuleFor(x => x.AmountHours, f => f.Random.Number(1, 6))
-            .RuleFor(a => a.AssignmentId, f => f.PickRandom(Assignments).Id)
-            .RuleFor(a => a.UserId, f => f.PickRandom(Users).Id)
             .RuleFor(o => o.CreatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(f.Random.Number(-24, -12))))
             .RuleFor(o => o.UpdatedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-12, -8)), DateTime.UtcNow.AddMonths(f.Random.Number(-6, -2))))
             .RuleFor(o => o.DeletedAt, f => f.Date.Between(DateTime.UtcNow.AddMonths(f.Random.Number(-11, -7)), DateTime.UtcNow.AddMonths(f.Random.Number(-7, -6))))
             .RuleFor(x => x.Active, f => f.Random.Bool());
 
         Appointments = appointmentFaker.Generate(489571);
+        foreach (var appointment in Appointments)
+        {
+            var assignment = PickRandom(Assignments, random);
+            appointment.AssignmentId = assignment.Id;
+            appointment.UserId = PickUserForOrganization(Users, userOrganizationIds, assignmentOrganizationIds[assignment.Id], random).Id;
+        }
+
         WriteCsv("Appointments.csv", Appointments, x =>
         [
             x.Id.ToString(),
@@ -623,6 +652,38 @@ internal static class FakeDataHelper
     }
 
     private static string EscapeSqlField(string value) => value.Replace("'", "''");
+
+    private static T PickRandom<T>(IReadOnlyList<T> values, Random random) => values[random.Next(values.Count)];
+
+    private static Project PickProjectForOrganization(IReadOnlyList<Project> projects, Guid organizationId, Random random)
+    {
+        var start = random.Next(projects.Count);
+        for (var offset = 0; offset < projects.Count; offset++)
+        {
+            var index = (start + offset) % projects.Count;
+            if (projects[index].OrganizationId == organizationId)
+            {
+                return projects[index];
+            }
+        }
+
+        throw new InvalidOperationException($"No project exists for organization {organizationId}.");
+    }
+
+    private static User PickUserForOrganization(IReadOnlyList<User> users, IReadOnlyDictionary<Guid, Guid> userOrganizationIds, Guid organizationId, Random random)
+    {
+        var start = random.Next(users.Count);
+        for (var offset = 0; offset < users.Count; offset++)
+        {
+            var index = (start + offset) % users.Count;
+            if (userOrganizationIds[users[index].Id] == organizationId)
+            {
+                return users[index];
+            }
+        }
+
+        throw new InvalidOperationException($"No user exists for organization {organizationId}.");
+    }
 
     private static string EscapeCsvField(string value)
     {

--- a/src/Infrastructure/Common/Helpers/FakeDataCsvImporter.cs
+++ b/src/Infrastructure/Common/Helpers/FakeDataCsvImporter.cs
@@ -2,7 +2,7 @@ namespace Infrastructure.Common.Helpers;
 
 public static class FakeDataCsvImporter
 {
-    private const string SeedVersion = "fake-data-csv-v2-20260528-active-visible";
+    private const string SeedVersion = "fake-data-csv-v3-20260528-tenant-scoped";
     private const string DefaultDemoLogin = "demo@cpnucleo.local";
     private const string DefaultDemoPassword = "CpnucleoDemo2026!";
     private const string DefaultDemoName = "Cpnucleo Demo";
@@ -48,24 +48,29 @@ public static class FakeDataCsvImporter
 
         var organizationIds = CreateIds(OrganizationCount);
         var projectIds = CreateIds(ProjectCount);
+        var projectOrganizationIds = new Guid[ProjectCount];
         var impedimentIds = CreateIds(ImpedimentCount);
         var assignmentTypeIds = CreateIds(AssignmentTypeCount);
         var workflowIds = CreateIds(WorkflowCount);
         var userIds = CreateIds(UserCount);
+        var userOrganizationIds = CreateRoundRobinTenancyAssignments(UserCount, organizationIds);
+        var userOrganizationIndexMap = BuildIndexMap(userOrganizationIds);
         var assignmentIds = CreateIds(AssignmentCount);
+        var assignmentOrganizationIds = new Guid[AssignmentCount];
 
         await ImportOrganizationsAsync(connection, organizationIds, logger, cancellationToken).ConfigureAwait(false);
-        await ImportProjectsAsync(connection, projectIds, organizationIds, logger, cancellationToken).ConfigureAwait(false);
+        await ImportProjectsAsync(connection, projectIds, organizationIds, projectOrganizationIds, random, logger, cancellationToken).ConfigureAwait(false);
+        var projectOrganizationIndexMap = BuildIndexMap(projectOrganizationIds);
         await ImportImpedimentsAsync(connection, impedimentIds, logger, cancellationToken).ConfigureAwait(false);
         await ImportAssignmentTypesAsync(connection, assignmentTypeIds, logger, cancellationToken).ConfigureAwait(false);
         await ImportWorkflowsAsync(connection, workflowIds, logger, cancellationToken).ConfigureAwait(false);
         await ImportUsersAsync(connection, userIds, fakeUserPasswordHash, logger, cancellationToken).ConfigureAwait(false);
         await InsertDefaultDemoUserAsync(connection, defaultDemoPasswordHash, cancellationToken).ConfigureAwait(false);
-        await ImportUserProjectsAsync(connection, userIds, projectIds, random, logger, cancellationToken).ConfigureAwait(false);
-        await ImportAssignmentsAsync(connection, assignmentIds, projectIds, workflowIds, userIds, assignmentTypeIds, random, logger, cancellationToken).ConfigureAwait(false);
-        await ImportUserAssignmentsAsync(connection, userIds, assignmentIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportUserProjectsAsync(connection, userIds, projectIds, projectOrganizationIds, projectOrganizationIndexMap, userOrganizationIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportAssignmentsAsync(connection, assignmentIds, projectIds, projectOrganizationIds, workflowIds, userIds, userOrganizationIds, userOrganizationIndexMap, assignmentTypeIds, assignmentOrganizationIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportUserAssignmentsAsync(connection, userIds, userOrganizationIndexMap, assignmentIds, assignmentOrganizationIds, random, logger, cancellationToken).ConfigureAwait(false);
         await ImportAssignmentImpedimentsAsync(connection, assignmentIds, impedimentIds, random, logger, cancellationToken).ConfigureAwait(false);
-        await ImportAppointmentsAsync(connection, assignmentIds, userIds, random, logger, cancellationToken).ConfigureAwait(false);
+        await ImportAppointmentsAsync(connection, assignmentIds, assignmentOrganizationIds, userIds, userOrganizationIndexMap, random, logger, cancellationToken).ConfigureAwait(false);
         await MarkSeedAppliedAsync(connection, startedAt, cancellationToken).ConfigureAwait(false);
 
         logger.LogWarning(
@@ -172,6 +177,25 @@ public static class FakeDataCsvImporter
         return ids;
     }
 
+    private static Guid[] CreateRoundRobinTenancyAssignments(int count, Guid[] organizationIds)
+    {
+        var assignments = new Guid[count];
+        for (var i = 0; i < assignments.Length; i++)
+        {
+            assignments[i] = organizationIds[i % organizationIds.Length];
+        }
+
+        return assignments;
+    }
+
+    private static Dictionary<Guid, int[]> BuildIndexMap(Guid[] organizationIds)
+    {
+        return organizationIds
+            .Select((organizationId, index) => new { organizationId, index })
+            .GroupBy(x => x.organizationId)
+            .ToDictionary(group => group.Key, group => group.Select(x => x.index).ToArray());
+    }
+
     private static async Task ImportOrganizationsAsync(NpgsqlConnection connection, Guid[] ids, ILogger logger, CancellationToken cancellationToken)
     {
         var faker = new Faker();
@@ -195,7 +219,7 @@ public static class FakeDataCsvImporter
         logger.LogInformation("Imported {Count} organizations via CSV COPY.", ids.Length);
     }
 
-    private static async Task ImportProjectsAsync(NpgsqlConnection connection, Guid[] ids, Guid[] organizationIds, ILogger logger, CancellationToken cancellationToken)
+    private static async Task ImportProjectsAsync(NpgsqlConnection connection, Guid[] ids, Guid[] organizationIds, Guid[] projectOrganizationIds, Random random, ILogger logger, CancellationToken cancellationToken)
     {
         var faker = new Faker();
         await using var writer = await connection.BeginTextImportAsync(
@@ -208,7 +232,7 @@ public static class FakeDataCsvImporter
             await writer.WriteLineAsync(Csv(
                 ids[i],
                 $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
-                faker.PickRandom(organizationIds),
+                projectOrganizationIds[i] = i < organizationIds.Length ? organizationIds[i] : Pick(organizationIds, random),
                 PastCreatedAt(faker),
                 PastUpdatedAt(faker),
                 active ? null : PastDeletedAt(faker),
@@ -282,23 +306,34 @@ public static class FakeDataCsvImporter
         logger.LogInformation("Imported {Count} users via CSV COPY.", ids.Length);
     }
 
-    private static async Task ImportUserProjectsAsync(NpgsqlConnection connection, Guid[] userIds, Guid[] projectIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    private static async Task ImportUserProjectsAsync(NpgsqlConnection connection, Guid[] userIds, Guid[] projectIds, Guid[] projectOrganizationIds, IReadOnlyDictionary<Guid, int[]> projectOrganizationIndexMap, Guid[] userOrganizationIds, Random random, ILogger logger, CancellationToken cancellationToken)
     {
         var faker = new Faker();
         await using var writer = await connection.BeginTextImportAsync(
             "COPY \"UserProjects\" (\"Id\", \"UserId\", \"ProjectId\", \"CreatedAt\", \"UpdatedAt\", \"DeletedAt\", \"Active\") FROM STDIN WITH (FORMAT CSV)",
             cancellationToken).ConfigureAwait(false);
 
-        for (var i = 0; i < UserProjectCount; i++)
+        var written = 0;
+        foreach (var projectId in projectIds)
         {
             var active = true;
-            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), Pick(userIds, random), Pick(projectIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), DefaultDemoUserId, projectId, PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+            written++;
         }
 
-        logger.LogInformation("Imported {Count} user projects via CSV COPY.", UserProjectCount);
+        for (; written < UserProjectCount; written++)
+        {
+            var active = true;
+            var userIndex = random.Next(userIds.Length);
+            var userOrganizationId = userOrganizationIds[userIndex];
+            var projectId = PickProjectForOrganization(projectIds, projectOrganizationIndexMap, userOrganizationId, random);
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), userIds[userIndex], projectId, PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+        }
+
+        logger.LogInformation("Imported {Count} tenant-scoped user projects via CSV COPY, including demo access to all {ProjectCount} projects.", UserProjectCount, projectIds.Length);
     }
 
-    private static async Task ImportAssignmentsAsync(NpgsqlConnection connection, Guid[] ids, Guid[] projectIds, Guid[] workflowIds, Guid[] userIds, Guid[] assignmentTypeIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    private static async Task ImportAssignmentsAsync(NpgsqlConnection connection, Guid[] ids, Guid[] projectIds, Guid[] projectOrganizationIds, Guid[] workflowIds, Guid[] userIds, Guid[] userOrganizationIds, IReadOnlyDictionary<Guid, int[]> userOrganizationIndexMap, Guid[] assignmentTypeIds, Guid[] assignmentOrganizationIds, Random random, ILogger logger, CancellationToken cancellationToken)
     {
         var faker = new Faker();
         await using var writer = await connection.BeginTextImportAsync(
@@ -308,6 +343,9 @@ public static class FakeDataCsvImporter
         for (var i = 0; i < ids.Length; i++)
         {
             var active = true;
+            var projectIndex = random.Next(projectIds.Length);
+            var projectOrganizationId = projectOrganizationIds[projectIndex];
+            assignmentOrganizationIds[i] = projectOrganizationId;
             await writer.WriteLineAsync(Csv(
                 ids[i],
                 $"{faker.Hacker.Noun()} {faker.Hacker.IngVerb()} {faker.Hacker.Adjective()}",
@@ -315,9 +353,9 @@ public static class FakeDataCsvImporter
                 AssignmentStartDate(faker),
                 AssignmentEndDate(faker),
                 faker.Random.Number(12, 60),
-                Pick(projectIds, random),
+                projectIds[projectIndex],
                 Pick(workflowIds, random),
-                Pick(userIds, random),
+                PickUserForOrganization(userIds, userOrganizationIndexMap, projectOrganizationId, random),
                 Pick(assignmentTypeIds, random),
                 PastCreatedAt(faker),
                 PastUpdatedAt(faker),
@@ -328,7 +366,7 @@ public static class FakeDataCsvImporter
         logger.LogInformation("Imported {Count} assignments via CSV COPY.", ids.Length);
     }
 
-    private static async Task ImportUserAssignmentsAsync(NpgsqlConnection connection, Guid[] userIds, Guid[] assignmentIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    private static async Task ImportUserAssignmentsAsync(NpgsqlConnection connection, Guid[] userIds, IReadOnlyDictionary<Guid, int[]> userOrganizationIndexMap, Guid[] assignmentIds, Guid[] assignmentOrganizationIds, Random random, ILogger logger, CancellationToken cancellationToken)
     {
         var faker = new Faker();
         await using var writer = await connection.BeginTextImportAsync(
@@ -338,7 +376,9 @@ public static class FakeDataCsvImporter
         for (var i = 0; i < UserAssignmentCount; i++)
         {
             var active = true;
-            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), Pick(userIds, random), Pick(assignmentIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+            var assignmentIndex = random.Next(assignmentIds.Length);
+            var assignmentOrganizationId = assignmentOrganizationIds[assignmentIndex];
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), PickUserForOrganization(userIds, userOrganizationIndexMap, assignmentOrganizationId, random), assignmentIds[assignmentIndex], PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
         logger.LogInformation("Imported {Count} user assignments via CSV COPY.", UserAssignmentCount);
@@ -360,7 +400,7 @@ public static class FakeDataCsvImporter
         logger.LogInformation("Imported {Count} assignment impediments via CSV COPY.", AssignmentImpedimentCount);
     }
 
-    private static async Task ImportAppointmentsAsync(NpgsqlConnection connection, Guid[] assignmentIds, Guid[] userIds, Random random, ILogger logger, CancellationToken cancellationToken)
+    private static async Task ImportAppointmentsAsync(NpgsqlConnection connection, Guid[] assignmentIds, Guid[] assignmentOrganizationIds, Guid[] userIds, IReadOnlyDictionary<Guid, int[]> userOrganizationIndexMap, Random random, ILogger logger, CancellationToken cancellationToken)
     {
         var faker = new Faker();
         await using var writer = await connection.BeginTextImportAsync(
@@ -370,13 +410,35 @@ public static class FakeDataCsvImporter
         for (var i = 0; i < AppointmentCount; i++)
         {
             var active = true;
-            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), faker.Hacker.Phrase(), KeepDate(faker), faker.Random.Number(1, 6), Pick(assignmentIds, random), Pick(userIds, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
+            var assignmentIndex = random.Next(assignmentIds.Length);
+            var assignmentOrganizationId = assignmentOrganizationIds[assignmentIndex];
+            await writer.WriteLineAsync(Csv(BaseEntity.GetNewId(), faker.Hacker.Phrase(), KeepDate(faker), faker.Random.Number(1, 6), assignmentIds[assignmentIndex], PickUserForOrganization(userIds, userOrganizationIndexMap, assignmentOrganizationId, random), PastCreatedAt(faker), PastUpdatedAt(faker), active ? null : PastDeletedAt(faker), active)).ConfigureAwait(false);
         }
 
         logger.LogInformation("Imported {Count} appointments via CSV COPY.", AppointmentCount);
     }
 
     private static Guid Pick(Guid[] values, Random random) => values[random.Next(values.Length)];
+
+    private static Guid PickProjectForOrganization(Guid[] projectIds, IReadOnlyDictionary<Guid, int[]> projectOrganizationIndexMap, Guid organizationId, Random random)
+    {
+        if (!projectOrganizationIndexMap.TryGetValue(organizationId, out var indexes) || indexes.Length == 0)
+        {
+            throw new InvalidOperationException($"No project exists for organization {organizationId}.");
+        }
+
+        return projectIds[indexes[random.Next(indexes.Length)]];
+    }
+
+    private static Guid PickUserForOrganization(Guid[] userIds, IReadOnlyDictionary<Guid, int[]> userOrganizationIndexMap, Guid organizationId, Random random)
+    {
+        if (!userOrganizationIndexMap.TryGetValue(organizationId, out var indexes) || indexes.Length == 0)
+        {
+            throw new InvalidOperationException($"No user exists for organization {organizationId}.");
+        }
+
+        return userIds[indexes[random.Next(indexes.Length)]];
+    }
 
     private static DateTimeOffset PastCreatedAt(Faker faker) => ToUtc(faker.Date.Between(DateTime.UtcNow.AddMonths(faker.Random.Number(-36, -24)), DateTime.UtcNow.AddMonths(faker.Random.Number(-24, -12))));
 

--- a/tests/Architecture.Tests/FakeDataSeedingTests.cs
+++ b/tests/Architecture.Tests/FakeDataSeedingTests.cs
@@ -36,7 +36,10 @@ public class FakeDataSeedingTests
         fakeData.Should().Contain("\"Organizations\"");
         fakeData.Should().Contain("\"Workflows\"");
         fakeData.Should().Contain("\"AssignmentTypes\"");
-        fakeData.Should().Contain("\"Impediments\"");
+        fakeData.Should().Contain("UserProject.Create(DefaultDemoUserId, project.Id)");
+        fakeData.Should().Contain("PickProjectForOrganization(Projects, userOrganizationIds[user.Id], random)");
+        fakeData.Should().Contain("PickUserForOrganization(Users, userOrganizationIds, organizationId, random)");
+        fakeData.Should().Contain("PickUserForOrganization(Users, userOrganizationIds, assignmentOrganizationIds[assignment.Id], random)");
     }
 
     [Fact]
@@ -57,6 +60,14 @@ public class FakeDataSeedingTests
         importer.Should().Contain("__FakeDataCsvImports");
         importer.Should().Contain("TRUNCATE TABLE");
         importer.Should().Contain("DefaultDemoLogin = \"demo@cpnucleo.local\"");
+        importer.Should().Contain("DefaultDemoUserId");
+        importer.Should().Contain("ImportUserProjectsAsync(connection, userIds, projectIds, projectOrganizationIds, projectOrganizationIndexMap, userOrganizationIds");
+        importer.Should().Contain("ImportAssignmentsAsync(connection, assignmentIds, projectIds, projectOrganizationIds, workflowIds, userIds, userOrganizationIds, userOrganizationIndexMap");
+        importer.Should().Contain("ImportUserAssignmentsAsync(connection, userIds, userOrganizationIndexMap, assignmentIds, assignmentOrganizationIds");
+        importer.Should().Contain("ImportAppointmentsAsync(connection, assignmentIds, assignmentOrganizationIds, userIds, userOrganizationIndexMap");
+        importer.Should().Contain("DefaultDemoUserId, projectId");
+        importer.Should().Contain("PickProjectForOrganization(projectIds, projectOrganizationIndexMap, userOrganizationId");
+        importer.Should().Contain("PickUserForOrganization(userIds, userOrganizationIndexMap, assignmentOrganizationId");
 
         program.Should().Contain("--run-fake-data-csv-import");
         program.Should().Contain("FakeDataCsvImporter.RunAsync");


### PR DESCRIPTION
## Summary
- assign every generated user to an organization-level tenancy scope
- make the demo user retain UserProject access to every generated project
- constrain non-demo UserProjects, Assignments, UserAssignments, and Appointments to users/projects within the same organization tenancy
- bump the one-shot CSV seed marker so production reseeds with the tenant-scoped dataset

## Tests
- dotnet test tests/Architecture.Tests/Architecture.Tests.csproj --no-restore -v minimal
- dotnet build src/WebApi/WebApi.csproj -c Release -p:AOT=false -p:Trim=true -p:ExtraOptimize=true --no-restore -v minimal
- dotnet test cpnucleo.slnx --no-restore -v minimal *(fails locally because WebApi.Integration.Tests cannot connect to local PostgreSQL 127.0.0.1:5432 and unauthenticated write requests return 401; unaffected unit/architecture/security projects pass before the integration environment failure)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced test data generation to maintain consistent organization-level relationships across all seeded entities.
  * Improved tenant-scoped data seeding pipeline with better organizational data consistency and automated relationship validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->