### PR TITLE
ci: add production smoke test step

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -320,3 +320,6 @@ jobs:
 
       - name: Deploy Hostinger project
         run: scripts/deploy-hostinger-docker-manager.sh
+
+      - name: Run production smoke tests
+        run: scripts/smoke-production.sh

--- a/scripts/deploy-hostinger-docker-manager.sh
+++ b/scripts/deploy-hostinger-docker-manager.sh
@@ -336,35 +336,4 @@ if grep -Eiq 'Unhandled exception|panic:|segmentation fault|no space left on dev
   exit 1
 fi
 
-check_url() {
-  local name="$1"
-  local url="$2"
-  local allowed_codes="${3:-200}"
-  [[ -z "${url}" ]] && return 0
-
-  for attempt in {1..30}; do
-    code="$(curl --connect-timeout 5 --max-time 15 -sS -o "${workdir}/smoke-body" -w "%{http_code}" "${url}" || true)"
-    if [[ ",${allowed_codes}," == *",${code},"* ]]; then
-      echo "${name} smoke passed: HTTP ${code}"
-      return 0
-    fi
-    echo "${name} smoke attempt ${attempt} got HTTP ${code}; retrying..."
-    sleep 10
-  done
-
-  echo "${name} smoke failed for ${url}" >&2
-  return 1
-}
-
-check_url "WebClient" "${CPNUCLEO_WEB_URL:-}" "200,301,302"
-if [[ -n "${CPNUCLEO_API_URL:-}" ]]; then
-  check_url "WebApi health" "${CPNUCLEO_API_URL%/}/healthz" "200"
-fi
-if [[ -n "${CPNUCLEO_IDENTITY_URL:-}" ]]; then
-  check_url "IdentityApi health" "${CPNUCLEO_IDENTITY_URL%/}/healthz" "200"
-fi
-if [[ -n "${CPNUCLEO_GRPC_HEALTH_URL:-}" ]]; then
-  check_url "Grpc health" "${CPNUCLEO_GRPC_HEALTH_URL}" "200"
-fi
-
 echo "Hostinger deployment completed successfully for ${tag}."

--- a/scripts/smoke-production.sh
+++ b/scripts/smoke-production.sh
@@ -14,15 +14,15 @@ check_url() {
     return 0
   fi
 
-  for attempt in {1..30}; do
-    code="$(curl --connect-timeout 5 --max-time 15 -sS -o "${workdir}/smoke-body" -w "%{http_code}" "${url}" || true)"
+  for attempt in {1..10}; do
+    code="$(curl --connect-timeout 5 --max-time 10 -sS -o "${workdir}/smoke-body" -w "%{http_code}" "${url}" || true)"
     if [[ ",${allowed_codes}," == *",${code},"* ]]; then
       echo "${name} smoke passed: HTTP ${code}"
       return 0
     fi
 
     echo "${name} smoke attempt ${attempt} got HTTP ${code}; retrying..."
-    sleep 10
+    sleep 5
   done
 
   echo "${name} smoke failed for ${url}" >&2

--- a/scripts/smoke-production.sh
+++ b/scripts/smoke-production.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+check_url() {
+  local name="$1"
+  local url="$2"
+  local allowed_codes="${3:-200}"
+
+  if [[ -z "${url}" ]]; then
+    echo "${name} smoke skipped: URL is empty"
+    return 0
+  fi
+
+  for attempt in {1..30}; do
+    code="$(curl --connect-timeout 5 --max-time 15 -sS -o "${workdir}/smoke-body" -w "%{http_code}" "${url}" || true)"
+    if [[ ",${allowed_codes}," == *",${code},"* ]]; then
+      echo "${name} smoke passed: HTTP ${code}"
+      return 0
+    fi
+
+    echo "${name} smoke attempt ${attempt} got HTTP ${code}; retrying..."
+    sleep 10
+  done
+
+  echo "${name} smoke failed for ${url}" >&2
+  if [[ -s "${workdir}/smoke-body" ]]; then
+    echo "Last response body preview:" >&2
+    head -c 500 "${workdir}/smoke-body" >&2 || true
+    echo >&2
+  fi
+  return 1
+}
+
+CPNUCLEO_WEB_URL="${CPNUCLEO_WEB_URL:-https://cpnucleo.jonathanperis.tech/}"
+CPNUCLEO_API_URL="${CPNUCLEO_API_URL:-https://api-cpnucleo.jonathanperis.tech}"
+CPNUCLEO_IDENTITY_URL="${CPNUCLEO_IDENTITY_URL:-https://identity-cpnucleo.jonathanperis.tech}"
+CPNUCLEO_GRPC_HEALTH_URL="${CPNUCLEO_GRPC_HEALTH_URL:-https://grpc-cpnucleo.jonathanperis.tech/healthz}"
+
+check_url "WebClient" "${CPNUCLEO_WEB_URL:-}" "200,301,302"
+if [[ -n "${CPNUCLEO_API_URL:-}" ]]; then
+  check_url "WebApi health" "${CPNUCLEO_API_URL%/}/healthz" "200"
+fi
+if [[ -n "${CPNUCLEO_IDENTITY_URL:-}" ]]; then
+  check_url "IdentityApi health" "${CPNUCLEO_IDENTITY_URL%/}/healthz" "200"
+fi
+if [[ -n "${CPNUCLEO_GRPC_HEALTH_URL:-}" ]]; then
+  check_url "Grpc health" "${CPNUCLEO_GRPC_HEALTH_URL}" "200"
+fi
+
+echo "Production smoke tests completed successfully."

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -383,11 +383,20 @@ public class FastEndpointsConfigurationTests
 
         releaseWorkflow.Should().Contain("- name: Run production smoke tests");
         releaseWorkflow.Should().Contain("run: scripts/smoke-production.sh");
+
+        var deployIndex = releaseWorkflow.IndexOf("- name: Deploy Hostinger project", StringComparison.Ordinal);
+        var smokeIndex = releaseWorkflow.IndexOf("- name: Run production smoke tests", StringComparison.Ordinal);
+        deployIndex.Should().BeGreaterThanOrEqualTo(0);
+        smokeIndex.Should().BeGreaterThan(deployIndex, "production smoke tests must run after the Hostinger deploy step");
+
         releaseWorkflow.Should().Contain("CPNUCLEO_WEB_URL: ${{ secrets.CPNUCLEO_WEB_URL }}");
         releaseWorkflow.Should().Contain("CPNUCLEO_API_URL: ${{ secrets.CPNUCLEO_API_URL }}");
         releaseWorkflow.Should().Contain("CPNUCLEO_IDENTITY_URL: ${{ secrets.CPNUCLEO_IDENTITY_URL }}");
         releaseWorkflow.Should().Contain("CPNUCLEO_GRPC_HEALTH_URL: ${{ secrets.CPNUCLEO_GRPC_HEALTH_URL }}");
 
+        smokeScript.Should().Contain("for attempt in {1..10}");
+        smokeScript.Should().Contain("--max-time 10");
+        smokeScript.Should().Contain("sleep 5");
         smokeScript.Should().Contain("check_url \"WebClient\" \"${CPNUCLEO_WEB_URL:-}\" \"200,301,302\"");
         smokeScript.Should().Contain("check_url \"WebApi health\" \"${CPNUCLEO_API_URL%/}/healthz\" \"200\"");
         smokeScript.Should().Contain("check_url \"IdentityApi health\" \"${CPNUCLEO_IDENTITY_URL%/}/healthz\" \"200\"");

--- a/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
+++ b/tests/Architecture.Tests/FastEndpointsConfigurationTests.cs
@@ -376,6 +376,25 @@ public class FastEndpointsConfigurationTests
     }
 
     [Fact]
+    public void MainReleasePipeline_ShouldRunProductionSmokeTestsAfterHostingerDeploy()
+    {
+        var releaseWorkflow = File.ReadAllText(GetRepositoryPath(".github/workflows/main-release.yml"));
+        var smokeScript = File.ReadAllText(GetRepositoryPath("scripts/smoke-production.sh"));
+
+        releaseWorkflow.Should().Contain("- name: Run production smoke tests");
+        releaseWorkflow.Should().Contain("run: scripts/smoke-production.sh");
+        releaseWorkflow.Should().Contain("CPNUCLEO_WEB_URL: ${{ secrets.CPNUCLEO_WEB_URL }}");
+        releaseWorkflow.Should().Contain("CPNUCLEO_API_URL: ${{ secrets.CPNUCLEO_API_URL }}");
+        releaseWorkflow.Should().Contain("CPNUCLEO_IDENTITY_URL: ${{ secrets.CPNUCLEO_IDENTITY_URL }}");
+        releaseWorkflow.Should().Contain("CPNUCLEO_GRPC_HEALTH_URL: ${{ secrets.CPNUCLEO_GRPC_HEALTH_URL }}");
+
+        smokeScript.Should().Contain("check_url \"WebClient\" \"${CPNUCLEO_WEB_URL:-}\" \"200,301,302\"");
+        smokeScript.Should().Contain("check_url \"WebApi health\" \"${CPNUCLEO_API_URL%/}/healthz\" \"200\"");
+        smokeScript.Should().Contain("check_url \"IdentityApi health\" \"${CPNUCLEO_IDENTITY_URL%/}/healthz\" \"200\"");
+        smokeScript.Should().Contain("check_url \"Grpc health\" \"${CPNUCLEO_GRPC_HEALTH_URL}\" \"200\"");
+    }
+
+    [Fact]
     public void ApplicationContainers_ShouldCheckHealthzEveryTenMinutes()
     {
         var compose = File.ReadAllText(GetRepositoryPath("compose.yaml"));


### PR DESCRIPTION
## Summary
- extract the production smoke checks into `scripts/smoke-production.sh`
- add an explicit `Run production smoke tests` step after the Hostinger deploy job
- cover the workflow smoke step with an architecture regression test

## Test Plan
- [x] `dotnet test tests/Architecture.Tests --filter MainReleasePipeline_ShouldRunProductionSmokeTestsAfterHostingerDeploy`
- [x] `dotnet test tests/Architecture.Tests`
- [x] `scripts/smoke-production.sh`
- [x] `actionlint .github/workflows/main-release.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated health verification checks that execute immediately following production deployments to validate that critical service endpoints are responding correctly.

* **Tests**
  * Added validation tests to ensure production health checks execute as part of the deployment workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->