### PR TITLE
fix: load all home card counters

### DIFF
--- a/src/WebClient/src/routes/index-counters.test.ts
+++ b/src/WebClient/src/routes/index-counters.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const sourcePath = fileURLToPath(new URL('./index.tsx', import.meta.url));
+const source = readFileSync(sourcePath, 'utf8');
+
+describe('home page resource counters', () => {
+  it('loads counts for every work-area card instead of only the featured cards', () => {
+    expect(source).toContain('Promise.all(resourceMetadata.map(async (resource) => {');
+    expect(source).not.toContain('resourceMetadata.slice(0, 6).map(async (resource)');
+  });
+
+  it('requests the smallest page needed when only totalCount is displayed', () => {
+    expect(source).toContain('webApiClient.list(resource.key, 1, 1)');
+    expect(source).not.toContain('webApiClient.list(resource.key, 1, 5)');
+  });
+});

--- a/src/WebClient/src/routes/index-counters.test.ts
+++ b/src/WebClient/src/routes/index-counters.test.ts
@@ -7,12 +7,12 @@ const source = readFileSync(sourcePath, 'utf8');
 
 describe('home page resource counters', () => {
   it('loads counts for every work-area card instead of only the featured cards', () => {
-    expect(source).toContain('Promise.all(resourceMetadata.map(async (resource) => {');
-    expect(source).not.toContain('resourceMetadata.slice(0, 6).map(async (resource)');
+    expect(source).toMatch(/Promise\.all\(\s*resourceMetadata\.map\(/);
+    expect(source).not.toMatch(/resourceMetadata\.slice\(\s*0\s*,\s*6\s*\)\.map\(/);
   });
 
   it('requests the smallest page needed when only totalCount is displayed', () => {
-    expect(source).toContain('webApiClient.list(resource.key, 1, 1)');
-    expect(source).not.toContain('webApiClient.list(resource.key, 1, 5)');
+    expect(source).toMatch(/webApiClient\.list\(\s*resource\.key\s*,\s*1\s*,\s*1\s*\)/);
+    expect(source).not.toMatch(/webApiClient\.list\(\s*resource\.key\s*,\s*1\s*,\s*5\s*\)/);
   });
 });

--- a/src/WebClient/src/routes/index.tsx
+++ b/src/WebClient/src/routes/index.tsx
@@ -13,8 +13,8 @@ export default component$(() => {
   const counts = useSignal<Record<string, number>>({});
   useVisibleTask$(async () => {
     const next: Record<string, number> = {};
-    await Promise.all(resourceMetadata.slice(0, 6).map(async (resource) => {
-      try { next[resource.key] = (await webApiClient.list(resource.key, 1, 5)).totalCount ?? 0; }
+    await Promise.all(resourceMetadata.map(async (resource) => {
+      try { next[resource.key] = (await webApiClient.list(resource.key, 1, 1)).totalCount ?? 0; }
       catch { next[resource.key] = 0; }
     }));
     counts.value = next;


### PR DESCRIPTION
## Summary
- Load dashboard counts for every resource card on the home page instead of only the first six resources.
- Request a one-row page for each count lookup because the UI only needs `totalCount`.
- Add regression coverage so future home cards cannot show counters that are never populated.

## Test Plan
- [x] `bun test src/routes/index-counters.test.ts`
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workspace live count display to fetch and show resource counts for all items instead of limiting results to the first six.
  * Optimized API request parameters for more efficient count retrieval operations.

* **Tests**
  * Added comprehensive test coverage for live count functionality to validate implementation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->