### PR TITLE
fix: show readable relation values in lists

### DIFF
--- a/src/WebClient/src/features/crud/crud-form.test.ts
+++ b/src/WebClient/src/features/crud/crud-form.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getCrudFormElement } from './crud-form';
+
+const formElement = { tagName: 'FORM' } as HTMLFormElement;
+const documentLikeTarget = { tagName: 'DOCUMENT' } as unknown as EventTarget;
+const buttonLikeTarget = { tagName: 'BUTTON' } as unknown as EventTarget;
+
+describe('CRUD form helpers', () => {
+  it('uses Qwik delegated currentTarget argument instead of the document-level event currentTarget', () => {
+    const delegatedSubmitEvent = {
+      currentTarget: documentLikeTarget,
+      target: buttonLikeTarget,
+    } as SubmitEvent;
+
+    expect(getCrudFormElement(delegatedSubmitEvent, formElement)).toBe(formElement);
+  });
+});

--- a/src/WebClient/src/features/crud/crud-form.ts
+++ b/src/WebClient/src/features/crud/crud-form.ts
@@ -1,0 +1,13 @@
+const isHtmlFormElement = (target: unknown): target is HTMLFormElement => {
+  if (!target || typeof target !== 'object') return false;
+  if (typeof HTMLFormElement !== 'undefined' && target instanceof HTMLFormElement) return true;
+  return 'tagName' in target && String((target as { tagName?: unknown }).tagName).toUpperCase() === 'FORM';
+};
+
+export const getCrudFormElement = (event: Event, currentTarget?: EventTarget | null): HTMLFormElement => {
+  if (isHtmlFormElement(currentTarget)) return currentTarget;
+  if (isHtmlFormElement(event.currentTarget)) return event.currentTarget;
+  if (isHtmlFormElement(event.target)) return event.target;
+
+  throw new TypeError('CRUD form submit target is unavailable.');
+};

--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -3,12 +3,7 @@ import { formFields, tableFields } from '~/lib/api/resource-metadata';
 import { webApiClient } from '~/lib/api/webapi-client';
 import type { ApiEntity, ResourceKey, ResourceMetadata } from '~/lib/api/types';
 import { buildPaginationItems, DEFAULT_PAGE_SIZE, getLastPage } from './pagination';
-
-const formatValue = (value: unknown): string => {
-  if (value === null || value === undefined || value === '') return '—';
-  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(value)) return new Date(value).toLocaleString();
-  return String(value);
-};
+import { displayEntityLabel, displayFieldValue } from './relation-display';
 
 const inputType = (type: string) => type === 'guid' ? 'text' : type;
 
@@ -64,7 +59,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
 
   useVisibleTask$(async ({ track }) => {
     track(() => resource.key);
-    const relationKeys = [...new Set(formFields(resource).map((field) => field.relation).filter(Boolean))] as ResourceKey[];
+    const relationKeys = [...new Set(resource.fields.map((field) => field.relation).filter(Boolean))] as ResourceKey[];
     await Promise.all(relationKeys.map(async (key) => {
       try { relations[key] = (await webApiClient.list(key, 1, 100)).items ?? []; } catch { relations[key] = []; }
     }));
@@ -146,7 +141,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
                   {field.relation ? (
                     <select name={field.name} required={field.required} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm">
                       <option value="">{`Select ${field.label.toLowerCase()}`}</option>
-                      {relation.map((option) => <option key={String(option.id)} value={String(option.id)} selected={String(option.id) === String(value ?? '')}>{formatValue(option.name ?? option.description ?? option.login ?? option.id)}</option>)}
+                      {relation.map((option) => <option key={String(option.id)} value={String(option.id)} selected={String(option.id) === String(value ?? '')}>{displayEntityLabel(option)}</option>)}
                     </select>
                   ) : field.type === 'textarea' ? (
                     <textarea name={field.name} required={field.required} rows={3} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm" value={String(value ?? '')} />
@@ -226,7 +221,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
             <table class="min-w-full divide-y divide-line text-sm">
               <thead class="bg-raised text-left text-xs font-semibold uppercase tracking-wide text-muted"><tr>{tableFields(resource).map((field) => <th key={field.name} class="px-4 py-3">{field.label}</th>)}<th class="px-4 py-3 text-right">Actions</th></tr></thead>
               <tbody class="divide-y divide-line">
-                {items.value.map((item) => <tr key={String(item.id)} class="hover:bg-raised/70">{tableFields(resource).map((field) => <td key={field.name} class="max-w-xs truncate px-4 py-3">{formatValue(item[field.name])}</td>)}<td class="whitespace-nowrap px-4 py-3 text-right"><button class="mr-2 text-accent" onClick$={() => (details.value = item)}>Details</button><button class="mr-2 text-accent" onClick$={() => startEdit(item)}>Edit</button><button class="text-danger" onClick$={() => remove(item)}>Delete</button></td></tr>)}
+                {items.value.map((item) => <tr key={String(item.id)} class="hover:bg-raised/70">{tableFields(resource).map((field) => <td key={field.name} class="max-w-xs truncate px-4 py-3">{displayFieldValue(item[field.name], field.relation, relations)}</td>)}<td class="whitespace-nowrap px-4 py-3 text-right"><button class="mr-2 text-accent" onClick$={() => (details.value = item)}>Details</button><button class="mr-2 text-accent" onClick$={() => startEdit(item)}>Edit</button><button class="text-danger" onClick$={() => remove(item)}>Delete</button></td></tr>)}
               </tbody>
             </table>
           </div>
@@ -261,7 +256,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
               <button class="rounded-md border border-line px-3 py-2" onClick$={() => (details.value = null)}>Close</button>
             </div>
             <dl class="divide-y divide-line rounded-lg border border-line">
-              {resource.fields.map((field) => <div key={field.name} class="grid grid-cols-3 gap-3 px-4 py-3 text-sm"><dt class="font-medium text-muted">{field.label}</dt><dd class="col-span-2 break-all">{formatValue(details.value?.[field.name])}</dd></div>)}
+              {resource.fields.map((field) => <div key={field.name} class="grid grid-cols-3 gap-3 px-4 py-3 text-sm"><dt class="font-medium text-muted">{field.label}</dt><dd class="col-span-2 break-all">{displayFieldValue(details.value?.[field.name], field.relation, relations)}</dd></div>)}
             </dl>
           </aside>
         </div>

--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -3,6 +3,7 @@ import { formFields, tableFields } from '~/lib/api/resource-metadata';
 import { webApiClient } from '~/lib/api/webapi-client';
 import type { ApiEntity, ResourceKey, ResourceMetadata } from '~/lib/api/types';
 import { buildPaginationItems, DEFAULT_PAGE_SIZE, getLastPage } from './pagination';
+import { getCrudFormElement } from './crud-form';
 import { collectMissingRelationIds, displayEntityLabel, displayFieldValue } from './relation-display';
 
 const inputType = (type: string) => type === 'guid' ? 'text' : type;
@@ -87,9 +88,9 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
   const startEdit = $((item: ApiEntity) => { selected.value = item; mode.value = 'edit'; });
   const cancelForm = $(() => { selected.value = null; mode.value = 'list'; });
 
-  const submit = $(async (event: SubmitEvent) => {
+  const submit = $(async (event: SubmitEvent, currentTarget: HTMLFormElement) => {
     event.preventDefault();
-    const form = event.currentTarget as HTMLFormElement;
+    const form = getCrudFormElement(event, currentTarget);
     const values = Object.fromEntries(new FormData(form).entries());
     const payload: Record<string, unknown> = {};
     for (const field of formFields(resource)) {

--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -3,7 +3,7 @@ import { formFields, tableFields } from '~/lib/api/resource-metadata';
 import { webApiClient } from '~/lib/api/webapi-client';
 import type { ApiEntity, ResourceKey, ResourceMetadata } from '~/lib/api/types';
 import { buildPaginationItems, DEFAULT_PAGE_SIZE, getLastPage } from './pagination';
-import { displayEntityLabel, displayFieldValue } from './relation-display';
+import { collectMissingRelationIds, displayEntityLabel, displayFieldValue } from './relation-display';
 
 const inputType = (type: string) => type === 'guid' ? 'text' : type;
 
@@ -62,6 +62,24 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
     const relationKeys = [...new Set(resource.fields.map((field) => field.relation).filter(Boolean))] as ResourceKey[];
     await Promise.all(relationKeys.map(async (key) => {
       try { relations[key] = (await webApiClient.list(key, 1, 100)).items ?? []; } catch { relations[key] = []; }
+    }));
+  });
+
+  useVisibleTask$(async ({ track }) => {
+    track(() => resource.key);
+    track(() => items.value);
+
+    const missing = collectMissingRelationIds(items.value, resource.fields, relations);
+    await Promise.all(Object.entries(missing).map(async ([key, ids]) => {
+      const resourceKey = key as ResourceKey;
+      const loaded = await Promise.all((ids ?? []).map(async (id) => {
+        try { return await webApiClient.get(resourceKey, id); } catch { return undefined; }
+      }));
+      const found = loaded.filter((entity): entity is ApiEntity => Boolean(entity));
+      if (found.length === 0) return;
+      const existing = relations[resourceKey] ?? [];
+      const existingIds = new Set(existing.map((entity) => String(entity.id ?? '')));
+      relations[resourceKey] = [...existing, ...found.filter((entity) => !existingIds.has(String(entity.id ?? '')))];
     }));
   });
 

--- a/src/WebClient/src/features/crud/relation-display.test.ts
+++ b/src/WebClient/src/features/crud/relation-display.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { ApiEntity } from '~/lib/api/types';
-import { displayEntityLabel, displayFieldValue } from './relation-display';
+import type { ApiEntity, FieldMetadata } from '~/lib/api/types';
+import { displayEntityLabel, displayFieldValue, collectMissingRelationIds } from './relation-display';
 
 const organizations: ApiEntity[] = [
   { id: 'org-1', name: 'Cpnucleo Core' },
@@ -25,5 +25,29 @@ describe('CRUD relation display values', () => {
 
   it('chooses a readable label before an id for relation options and details', () => {
     expect(displayEntityLabel({ id: 'user-1', login: 'demo@cpnucleo.test' })).toBe('demo@cpnucleo.test');
+  });
+
+  it('skips empty display fields before falling back to the next readable value', () => {
+    expect(displayEntityLabel({ id: 'project-1', name: '', description: 'Readable description' })).toBe('Readable description');
+  });
+
+  it('collects only visible relation ids missing from the prefetched relation records', () => {
+    const fields = [
+      { name: 'projectId', label: 'Project', type: 'guid', relation: 'projects' },
+      { name: 'workflowId', label: 'Progress step', type: 'guid', relation: 'workflows' },
+      { name: 'name', label: 'Name', type: 'text' },
+    ] satisfies FieldMetadata[];
+
+    expect(collectMissingRelationIds([
+      { projectId: 'project-1', workflowId: 'todo' },
+      { projectId: 'project-2', workflowId: 'todo' },
+      { projectId: 'project-2', workflowId: '' },
+    ], fields, {
+      projects: [{ id: 'project-1', name: 'Already loaded' }],
+      workflows: [],
+    })).toEqual({
+      projects: ['project-2'],
+      workflows: ['todo'],
+    });
   });
 });

--- a/src/WebClient/src/features/crud/relation-display.test.ts
+++ b/src/WebClient/src/features/crud/relation-display.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import type { ApiEntity } from '~/lib/api/types';
+import { displayEntityLabel, displayFieldValue } from './relation-display';
+
+const organizations: ApiEntity[] = [
+  { id: 'org-1', name: 'Cpnucleo Core' },
+];
+
+const tasks: ApiEntity[] = [
+  { id: 'task-1', description: 'Write project plan' },
+];
+
+describe('CRUD relation display values', () => {
+  it('uses related record names in table cells instead of raw ids', () => {
+    expect(displayFieldValue('org-1', 'organizations', { organizations })).toBe('Cpnucleo Core');
+  });
+
+  it('falls back to related descriptions when a related record has no name', () => {
+    expect(displayFieldValue('task-1', 'assignments', { assignments: tasks })).toBe('Write project plan');
+  });
+
+  it('keeps the raw id visible when the related record is not loaded yet', () => {
+    expect(displayFieldValue('missing-id', 'organizations', { organizations })).toBe('missing-id');
+  });
+
+  it('chooses a readable label before an id for relation options and details', () => {
+    expect(displayEntityLabel({ id: 'user-1', login: 'demo@cpnucleo.test' })).toBe('demo@cpnucleo.test');
+  });
+});

--- a/src/WebClient/src/features/crud/relation-display.ts
+++ b/src/WebClient/src/features/crud/relation-display.ts
@@ -1,4 +1,4 @@
-import type { ApiEntity, ResourceKey } from '~/lib/api/types';
+import type { ApiEntity, FieldMetadata, ResourceKey } from '~/lib/api/types';
 
 export type RelationRecords = Partial<Record<ResourceKey, ApiEntity[]>>;
 
@@ -10,11 +10,32 @@ export const formatValue = (value: unknown): string => {
 
 export const displayEntityLabel = (entity: ApiEntity | undefined): string => {
   if (!entity) return '—';
-  return formatValue(entity.name ?? entity.description ?? entity.login ?? entity.id);
+  return formatValue(entity.name || entity.description || entity.login || entity.id);
 };
 
 export const displayFieldValue = (value: unknown, relation: ResourceKey | undefined, relations: RelationRecords): string => {
   if (!relation) return formatValue(value);
   const related = relations[relation]?.find((entity) => String(entity.id ?? '') === String(value ?? ''));
   return related ? displayEntityLabel(related) : formatValue(value);
+};
+
+export const collectMissingRelationIds = (items: ApiEntity[], fields: FieldMetadata[], relations: RelationRecords): Partial<Record<ResourceKey, string[]>> => {
+  const missing: Partial<Record<ResourceKey, string[]>> = {};
+
+  for (const field of fields) {
+    if (!field.relation) continue;
+    const loadedIds = new Set((relations[field.relation] ?? []).map((entity) => String(entity.id ?? '')));
+    const missingIds = new Set<string>();
+
+    for (const item of items) {
+      const value = item[field.name];
+      if (value === null || value === undefined || value === '') continue;
+      const id = String(value);
+      if (!loadedIds.has(id)) missingIds.add(id);
+    }
+
+    if (missingIds.size > 0) missing[field.relation] = [...missingIds];
+  }
+
+  return missing;
 };

--- a/src/WebClient/src/features/crud/relation-display.ts
+++ b/src/WebClient/src/features/crud/relation-display.ts
@@ -1,0 +1,20 @@
+import type { ApiEntity, ResourceKey } from '~/lib/api/types';
+
+export type RelationRecords = Partial<Record<ResourceKey, ApiEntity[]>>;
+
+export const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === '') return '—';
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(value)) return new Date(value).toLocaleString();
+  return String(value);
+};
+
+export const displayEntityLabel = (entity: ApiEntity | undefined): string => {
+  if (!entity) return '—';
+  return formatValue(entity.name ?? entity.description ?? entity.login ?? entity.id);
+};
+
+export const displayFieldValue = (value: unknown, relation: ResourceKey | undefined, relations: RelationRecords): string => {
+  if (!relation) return formatValue(value);
+  const related = relations[relation]?.find((entity) => String(entity.id ?? '') === String(value ?? ''));
+  return related ? displayEntityLabel(related) : formatValue(value);
+};


### PR DESCRIPTION
## Summary
- Show readable related-record labels in CRUD listing tables and details instead of raw foreign-key IDs.
- Reuse the same display preference (`name`, then `description`, then `login`, then `id`) for relation dropdowns, table cells, and details.
- Load relation data from all resource fields so table-only related fields can be resolved too.
- Add regression coverage for relation label resolution and fallback behavior.

## Test Plan
- [x] `bun test src/features/crud/relation-display.test.ts`
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Related entities now display with human-readable names and descriptions instead of raw IDs
  * Date values are formatted using localized date strings for better readability
  * Improved handling of missing or empty values in data tables and record details

* **Tests**
  * Added test coverage for relation display functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->