### PR TITLE
fix: return success after organization edits

### DIFF
--- a/src/WebApi/Endpoints/Organization/UpdateOrganization/Endpoint.cs
+++ b/src/WebApi/Endpoints/Organization/UpdateOrganization/Endpoint.cs
@@ -32,6 +32,9 @@ public class Endpoint(IUnitOfWork unitOfWork) : Endpoint<Request, Response>
         Logger.LogInformation("Updating organization entity with Id: {OrganizationId}", request.Id);
         Domain.Entities.Organization.Update(item, request.Name, request.Description);
 
+        Logger.LogInformation("Beginning transaction.");
+        await unitOfWork.BeginTransactionAsync();
+
         Logger.LogInformation("Updating entity in repository.");
         Response.Success = await repository.UpdateAsync(item);
 

--- a/tests/WebApi.Unit.Tests/Endpoints/OrganizationEndpointsTests.cs
+++ b/tests/WebApi.Unit.Tests/Endpoints/OrganizationEndpointsTests.cs
@@ -114,6 +114,8 @@ public class OrganizationEndpointsTests
         // Assert
         ep.Response.ShouldNotBeNull();
         ep.Response.Success.ShouldBeTrue();
+        A.CallTo(() => fakeUnitOfWork.BeginTransactionAsync()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => fakeUnitOfWork.CommitAsync(A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- start a unit-of-work transaction before updating organizations through WebApi
- add regression coverage requiring the organization update endpoint to begin and commit the transaction

## Root cause
Organization edits were persisted by Dapper outside a transaction, then the endpoint called `CommitAsync()`. `UnitOfWork.CommitAsync()` throws when no transaction was started, so the database update survived but the API returned HTTP 500 and the WebClient displayed “The server returned an unexpected error.”

## Tests
- `dotnet test tests/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj --filter "FullyQualifiedName~OrganizationEndpointsTests.UpdateOrganization_WithValidData_ShouldUpdateOrganization" --no-restore`
- `dotnet test tests/WebApi.Unit.Tests/WebApi.Unit.Tests.csproj --filter "FullyQualifiedName~OrganizationEndpointsTests" --no-restore`
- `dotnet build cpnucleo.slnx --no-restore`
