### PR TITLE
fix: prefill CRUD edit controls

### DIFF
--- a/src/WebClient/src/features/crud/crud-field-values.test.ts
+++ b/src/WebClient/src/features/crud/crud-field-values.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatFormFieldValue, relationOptionsLoaded } from './crud-field-values';
+
+describe('CRUD edit form field values', () => {
+  it('formats existing date and datetime values for browser edit controls', () => {
+    expect(formatFormFieldValue('2026-05-29T18:42:31.123Z', 'date')).toBe('2026-05-29');
+    expect(formatFormFieldValue('2026-05-29T18:42:31.123Z', 'datetime-local')).toBe('2026-05-29T18:42');
+    expect(formatFormFieldValue(new Date(Date.UTC(2026, 4, 29, 18, 42)), 'datetime-local')).toBe('2026-05-29T18:42');
+  });
+
+  it('keeps relation ids and numeric values available for select and number controls', () => {
+    expect(formatFormFieldValue('018fd27a-2145-7dd0-93b4-5d06071c2e9d', 'guid')).toBe('018fd27a-2145-7dd0-93b4-5d06071c2e9d');
+    expect(formatFormFieldValue(12.5, 'number')).toBe('12.5');
+    expect(formatFormFieldValue(null, 'text')).toBe('');
+  });
+
+  it('tracks whether relation options have loaded before rendering editable selectors', () => {
+    expect(relationOptionsLoaded({}, 'organizations')).toBe(false);
+    expect(relationOptionsLoaded({ organizations: [] }, 'organizations')).toBe(true);
+    expect(relationOptionsLoaded({}, undefined)).toBe(true);
+  });
+});

--- a/src/WebClient/src/features/crud/crud-field-values.ts
+++ b/src/WebClient/src/features/crud/crud-field-values.ts
@@ -1,0 +1,44 @@
+import type { FieldMetadata, ResourceKey } from '~/lib/api/types';
+
+const toDate = (value: unknown) => {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+};
+
+const pad = (value: number) => String(value).padStart(2, '0');
+
+const formatDateInputValue = (value: unknown) => {
+  if (typeof value === 'string') {
+    const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (match) return match[1];
+  }
+
+  const date = toDate(value);
+  if (!date) return value == null ? '' : String(value);
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+};
+
+const formatDateTimeLocalInputValue = (value: unknown) => {
+  if (typeof value === 'string') {
+    const match = value.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})/);
+    if (match) return match[1];
+  }
+
+  const date = toDate(value);
+  if (!date) return value == null ? '' : String(value);
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+};
+
+export const formatFormFieldValue = (value: unknown, fieldType: FieldMetadata['type']) => {
+  if (value == null) return '';
+  if (fieldType === 'date') return formatDateInputValue(value);
+  if (fieldType === 'datetime-local') return formatDateTimeLocalInputValue(value);
+  return String(value);
+};
+
+export const relationOptionsLoaded = (relations: Partial<Record<ResourceKey, unknown[]>>, relation: ResourceKey | undefined) => {
+  if (!relation) return true;
+  return Object.prototype.hasOwnProperty.call(relations, relation);
+};

--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -4,6 +4,7 @@ import { webApiClient } from '~/lib/api/webapi-client';
 import type { ApiEntity, ResourceKey, ResourceMetadata } from '~/lib/api/types';
 import { buildPaginationItems, DEFAULT_PAGE_SIZE, getLastPage } from './pagination';
 import { getCrudFormElement } from './crud-form';
+import { formatFormFieldValue, relationOptionsLoaded } from './crud-field-values';
 import { collectMissingRelationIds, displayEntityLabel, displayFieldValue } from './relation-display';
 
 const inputType = (type: string) => type === 'guid' ? 'text' : type;
@@ -153,20 +154,21 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             {formFields(resource).map((field) => {
-              const value = selected.value?.[field.name];
-              const relation = field.relation ? relations[field.relation] ?? [] : [];
+              const value = formatFormFieldValue(selected.value?.[field.name], field.type);
+              const relationLoaded = relationOptionsLoaded(relations, field.relation);
+              const relation = field.relation && relationLoaded ? relations[field.relation] ?? [] : [];
               return (
                 <label key={field.name} class={field.type === 'textarea' ? 'md:col-span-2' : ''}>
                   <span class="mb-1 block text-sm font-medium">{field.label}{field.required ? ' *' : ''}</span>
                   {field.relation ? (
-                    <select name={field.name} required={field.required} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm">
-                      <option value="">{`Select ${field.label.toLowerCase()}`}</option>
-                      {relation.map((option) => <option key={String(option.id)} value={String(option.id)} selected={String(option.id) === String(value ?? '')}>{displayEntityLabel(option)}</option>)}
+                    <select name={field.name} required={field.required} value={value} disabled={!relationLoaded} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm disabled:opacity-70">
+                      <option value="">{relationLoaded ? `Select ${field.label.toLowerCase()}` : 'Loading options…'}</option>
+                      {relation.map((option) => <option key={String(option.id)} value={String(option.id)}>{displayEntityLabel(option)}</option>)}
                     </select>
                   ) : field.type === 'textarea' ? (
-                    <textarea name={field.name} required={field.required} rows={3} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm" value={String(value ?? '')} />
+                    <textarea name={field.name} required={field.required} rows={3} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm" value={value} />
                   ) : (
-                    <input name={field.name} required={field.required} type={inputType(field.type)} step={field.type === 'number' ? '0.25' : undefined} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm" value={String(value ?? '')} />
+                    <input name={field.name} required={field.required} type={inputType(field.type)} step={field.type === 'number' ? '0.25' : undefined} class="w-full rounded-lg border border-line bg-raised px-3 py-2 text-sm" value={value} />
                   )}
                 </label>
               );


### PR DESCRIPTION
## Summary
- normalize existing date/datetime values before rendering CRUD edit controls
- bind relation dropdowns from the selected record with select value instead of static selected option attributes
- add regression tests covering edit field formatting and select binding

## Verification
- `bun test && bun run typecheck && bun run build` from `src/WebClient`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utility for normalizing and formatting form field values based on field type in edit forms.

* **Bug Fixes**
  * Enhanced relation select controls in CRUD edit forms to use controlled component pattern.

* **Tests**
  * Added comprehensive test coverage for form field value formatting across different field types.
  * Added test coverage for CRUD form control bindings and value normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->