### PR TITLE
fix: resolve readable relation labels

### DIFF
--- a/src/WebClient/src/features/crud/relation-display.test.ts
+++ b/src/WebClient/src/features/crud/relation-display.test.ts
@@ -27,6 +27,14 @@ describe('CRUD relation display values', () => {
     expect(displayEntityLabel({ id: 'user-1', login: 'demo@cpnucleo.test' })).toBe('demo@cpnucleo.test');
   });
 
+  it('combines name and description for richer relation labels', () => {
+    expect(displayEntityLabel({ id: 'task-1', name: 'Build API', description: 'Create endpoint contract' })).toBe('Build API — Create endpoint contract');
+  });
+
+  it('combines name and login for people relation labels', () => {
+    expect(displayEntityLabel({ id: 'user-1', name: 'Cpnucleo Demo', login: 'demo@cpnucleo.test' })).toBe('Cpnucleo Demo (demo@cpnucleo.test)');
+  });
+
   it('skips empty display fields before falling back to the next readable value', () => {
     expect(displayEntityLabel({ id: 'project-1', name: '', description: 'Readable description' })).toBe('Readable description');
   });

--- a/src/WebClient/src/features/crud/relation-display.ts
+++ b/src/WebClient/src/features/crud/relation-display.ts
@@ -8,9 +8,16 @@ export const formatValue = (value: unknown): string => {
   return String(value);
 };
 
+const nonEmptyString = (value: unknown): string => typeof value === 'string' && value.trim() ? value.trim() : '';
+
 export const displayEntityLabel = (entity: ApiEntity | undefined): string => {
   if (!entity) return '—';
-  return formatValue(entity.name || entity.description || entity.login || entity.id);
+  const name = nonEmptyString(entity.name);
+  const description = nonEmptyString(entity.description);
+  const login = nonEmptyString(entity.login);
+  if (name && description && description !== name) return `${name} — ${description}`;
+  if (name && login && login !== name) return `${name} (${login})`;
+  return formatValue(name || description || login || entity.id);
 };
 
 export const displayFieldValue = (value: unknown, relation: ResourceKey | undefined, relations: RelationRecords): string => {

--- a/src/WebClient/src/lib/api/webapi-client.test.ts
+++ b/src/WebClient/src/lib/api/webapi-client.test.ts
@@ -51,6 +51,15 @@ describe('webapi client', () => {
     expect((fetchMock.mock.calls[1][1] as RequestInit).method).toBe('PATCH');
   });
 
+  it('unwraps singular item response envelopes for relation lookups', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      organization: { id: 'org-1', name: 'Cpnucleo Core' },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const client = createWebApiClient('http://example.test/api');
+
+    await expect(client.get('organizations', 'org-1')).resolves.toEqual({ id: 'org-1', name: 'Cpnucleo Core' });
+  });
+
   it('adds the appointment name required by WebApi from the visible description field', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ id: 'abc' }), { status: 200 }));
     const client = createWebApiClient('http://example.test/api');

--- a/src/WebClient/src/lib/api/webapi-client.ts
+++ b/src/WebClient/src/lib/api/webapi-client.ts
@@ -13,6 +13,7 @@ const withQuery = (url: string, params?: Record<string, string | number | undefi
 };
 
 type ListEnvelope<T extends ApiEntity> = T[] | PaginatedResult<T> | { result?: PaginatedResult<T> };
+type ItemEnvelope<T extends ApiEntity> = T | { result?: T } | Record<string, unknown>;
 type ListSubscriber<T extends ApiEntity> = (page: PaginatedResult<T>) => void;
 
 export const normalizeList = <T extends ApiEntity>(payload: ListEnvelope<T>): PaginatedResult<T> => {
@@ -25,6 +26,16 @@ export const normalizeList = <T extends ApiEntity>(payload: ListEnvelope<T>): Pa
     pageNumber: page.pageNumber ?? page.page ?? 1,
     pageSize: page.pageSize ?? page.items?.length ?? page.data?.length ?? page.results?.length ?? 0,
   };
+};
+
+export const normalizeItem = <T extends ApiEntity>(payload: ItemEnvelope<T>, envelopeKey: string): T => {
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    if (record.id !== undefined) return payload as T;
+    if (record.result && typeof record.result === 'object') return record.result as T;
+    if (record[envelopeKey] && typeof record[envelopeKey] === 'object') return record[envelopeKey] as T;
+  }
+  return payload as T;
 };
 
 export const parseServerSentEventData = (event: string): string[] => {
@@ -161,7 +172,8 @@ export const createWebApiClient = (baseUrl = WEBAPI_BASE_URL) => {
     },
     async get<T extends ApiEntity>(resourceKey: ResourceKey, id: string, signal?: AbortSignal) {
       const resource = findResource(resourceKey);
-      return requestJson<T>(withQuery(`${root}${resource.itemPath}`, { id }), { signal });
+      const envelopeKey = resource.itemPath.replace(/^\//, '');
+      return normalizeItem<T>(await requestJson<ItemEnvelope<T>>(withQuery(`${root}${resource.itemPath}`, { id }), { signal }), envelopeKey);
     },
     async create<T extends ApiEntity>(resourceKey: ResourceKey, body: Record<string, unknown>) {
       const resource = findResource(resourceKey);


### PR DESCRIPTION
## Summary
- unwrap singular WebApi item response envelopes before using `get(...)` results for relation lookup labels
- render richer readable relation labels by combining `name + description` or `name + login` when both are available
- keep the raw id only as a fallback when the related record cannot be loaded

## Verification
- `bun test && bun run typecheck && bun run build` from `src/WebClient`

## Notes
This addresses mixed list rows where some relationships showed names and others showed ids because on-demand relation lookups were storing the server envelope (for example `{ organization: {...} }`) instead of the entity itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entity labels now display with improved formatting, intelligently combining name with description or login fields when available.

* **Tests**
  * Added test coverage for entity label display and API response handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonathanperis/cpnucleo/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->