### PR TITLE
fix: preserve fetched relation labels

### DIFF
--- a/src/WebClient/src/features/crud/crud-page.tsx
+++ b/src/WebClient/src/features/crud/crud-page.tsx
@@ -5,7 +5,7 @@ import type { ApiEntity, ResourceKey, ResourceMetadata } from '~/lib/api/types';
 import { buildPaginationItems, DEFAULT_PAGE_SIZE, getLastPage } from './pagination';
 import { getCrudFormElement } from './crud-form';
 import { formatFormFieldValue, relationOptionsLoaded, withSelectedRelationOption } from './crud-field-values';
-import { collectMissingRelationIds, displayEntityLabel, displayFieldValue } from './relation-display';
+import { collectMissingRelationIds, displayEntityLabel, displayFieldValue, mergeRelationRecords } from './relation-display';
 
 const inputType = (type: string) => type === 'guid' ? 'text' : type;
 
@@ -63,7 +63,10 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
     track(() => resource.key);
     const relationKeys = [...new Set(resource.fields.map((field) => field.relation).filter(Boolean))] as ResourceKey[];
     await Promise.all(relationKeys.map(async (key) => {
-      try { relations[key] = (await webApiClient.list(key, 1, 100)).items ?? []; } catch { relations[key] = []; }
+      try {
+        const fetched = (await webApiClient.list(key, 1, 100)).items ?? [];
+        relations[key] = mergeRelationRecords(relations[key] ?? [], fetched);
+      } catch { relations[key] = relations[key] ?? []; }
     }));
   });
 
@@ -80,8 +83,7 @@ export const CrudPage = component$<{ resource: ResourceMetadata }>(({ resource }
       const found = loaded.filter((entity): entity is ApiEntity => Boolean(entity));
       if (found.length === 0) return;
       const existing = relations[resourceKey] ?? [];
-      const existingIds = new Set(existing.map((entity) => String(entity.id ?? '')));
-      relations[resourceKey] = [...existing, ...found.filter((entity) => !existingIds.has(String(entity.id ?? '')))];
+      relations[resourceKey] = mergeRelationRecords(existing, found);
     }));
   });
 

--- a/src/WebClient/src/features/crud/relation-display.test.ts
+++ b/src/WebClient/src/features/crud/relation-display.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ApiEntity, FieldMetadata } from '~/lib/api/types';
-import { displayEntityLabel, displayFieldValue, collectMissingRelationIds } from './relation-display';
+import { displayEntityLabel, displayFieldValue, collectMissingRelationIds, mergeRelationRecords } from './relation-display';
 
 const organizations: ApiEntity[] = [
   { id: 'org-1', name: 'Cpnucleo Core' },
@@ -37,6 +37,16 @@ describe('CRUD relation display values', () => {
 
   it('skips empty display fields before falling back to the next readable value', () => {
     expect(displayEntityLabel({ id: 'project-1', name: '', description: 'Readable description' })).toBe('Readable description');
+  });
+
+  it('merges prefetched and on-demand relation records without dropping missing-page lookups', () => {
+    expect(mergeRelationRecords(
+      [{ id: 'org-missing', name: 'Fetched by id' }],
+      [{ id: 'org-page', name: 'Prefetched page' }, { id: 'org-missing', name: 'Duplicate from page' }],
+    )).toEqual([
+      { id: 'org-missing', name: 'Fetched by id' },
+      { id: 'org-page', name: 'Prefetched page' },
+    ]);
   });
 
   it('collects only visible relation ids missing from the prefetched relation records', () => {

--- a/src/WebClient/src/features/crud/relation-display.ts
+++ b/src/WebClient/src/features/crud/relation-display.ts
@@ -10,6 +10,11 @@ export const formatValue = (value: unknown): string => {
 
 const nonEmptyString = (value: unknown): string => typeof value === 'string' && value.trim() ? value.trim() : '';
 
+export const mergeRelationRecords = (existing: ApiEntity[], incoming: ApiEntity[]): ApiEntity[] => {
+  const existingIds = new Set(existing.map((entity) => String(entity.id ?? '')));
+  return [...existing, ...incoming.filter((entity) => !existingIds.has(String(entity.id ?? '')))];
+};
+
 export const displayEntityLabel = (entity: ApiEntity | undefined): string => {
   if (!entity) return '—';
   const name = nonEmptyString(entity.name);


### PR DESCRIPTION
## Summary
- merge prefetched relation pages with on-demand relation lookups instead of overwriting them
- preserves labels for rows whose related record is outside the first prefetched page
- keeps richer relation labels from PR #251 (`name — description`, `name (login)`)

## Verification
- `bun test src/features/crud/relation-display.test.ts`
- `bun run typecheck`
- `bun run build`

## Root cause
The list prefetch task and visible-row lookup task could race. If the visible-row lookup loaded an off-page organization first, the later first-page prefetch overwrote `relations[organizations]`, which made those rows fall back to raw ids again.
