### PR TITLE
docs: document WebClient CRUD behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,10 @@ cpnucleo/
 
 | Suite | Framework | Tests | Purpose |
 |-------|-----------|-------|---------|
-| Architecture.Tests | xUnit + NetArchTest + FluentAssertions | 27 | Layer deps, naming, sealed entities |
+| Architecture.Tests | xUnit + NetArchTest + FluentAssertions | 55 | Layer deps, naming, source checks, sealed entities |
 | Application.Unit.Tests | NUnit + FakeItEasy + Shouldly | 4 | Shared Application use cases |
-| WebApi.Unit.Tests | NUnit + FakeItEasy + Shouldly | 49 | Endpoint happy/negative paths |
+| Security.Unit.Tests | NUnit + Shouldly | 11 | Password hashing and login verification |
+| WebApi.Unit.Tests | NUnit + FakeItEasy + Shouldly | 53 | Endpoint happy/negative paths |
 | WebApi.Integration.Tests | xUnit v3 + FastEndpoints.Testing | 50+ | Full HTTP CRUD per entity |
 
 **CI note:** Unit and integration tests are currently commented out in `build-check.yml` — only architecture tests run in CI.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Cpnucleo is a project management and task tracking system built as a .NET 10 ref
 - OpenTelemetry observability with OTLP export and optional Grafana LGTM stack
 - NGINX load balancing across two WebApi instances with least-connection routing
 - Multi-platform Docker builds (linux/amd64 + linux/arm64/v8) with AOT, trimming, and extra optimization options
-- Astro + Qwik frontend with Tailwind CSS, IdentityApi login, and Catalyst-inspired CRUD screens for all WebApi resources
-- Three test suites: architecture validation (xUnit + NetArchTest), unit tests (NUnit + FakeItEasy), integration tests (xUnit v3 + FastEndpoints.Testing)
+- Astro + Qwik frontend with Tailwind CSS, IdentityApi login, and Catalyst-inspired CRUD screens for all WebApi resources, including prefilled edit forms and readable relation labels
+- Five test projects: architecture validation, Application and security unit tests, WebApi unit tests, and WebApi integration tests
 - Automated CI/CD with GitHub Actions deploying GHCR images to Hostinger Docker Manager
 
 ## Architecture
@@ -144,7 +144,9 @@ dotnet test tests/WebApi.Unit.Tests/            # Unit tests only
 | Suite | Framework | Coverage |
 |-------|-----------|----------|
 | Architecture.Tests | xUnit + NetArchTest | Layer deps, naming, sealed entities |
-| WebApi.Unit.Tests | NUnit + FakeItEasy + Shouldly | 49 endpoint unit-test cases; local compile cleanup currently needed |
+| Application.Unit.Tests | NUnit + FakeItEasy + Shouldly | Shared Application use cases |
+| Security.Unit.Tests | NUnit + Shouldly | Password hashing and login verification |
+| WebApi.Unit.Tests | NUnit + FakeItEasy + Shouldly | 53 endpoint unit-test cases; local compile cleanup currently needed |
 | WebApi.Integration.Tests | xUnit v3 + FastEndpoints.Testing | Full HTTP CRUD per entity |
 
 ## CI/CD
@@ -155,7 +157,7 @@ dotnet test tests/WebApi.Unit.Tests/            # Unit tests only
 
 ## Documentation
 
-See the [Pages documentation](https://jonathanperis.github.io/cpnucleo/docs/) for detailed documentation on architecture, API reference, database setup, testing, and deployment.
+See the [Pages documentation](https://jonathanperis.github.io/cpnucleo/docs/) for detailed documentation on architecture, API reference, WebClient CRUD behavior, database setup, testing, and deployment.
 
 ## Contributing
 

--- a/docs/src/lib/sidebar.config.ts
+++ b/docs/src/lib/sidebar.config.ts
@@ -1,6 +1,6 @@
 export const SECTION_CATEGORIES = [
   { label: "", ids: ["home"] },
-  { label: "Overview", ids: ["architecture", "api-reference", "database"] },
+  { label: "Overview", ids: ["architecture", "api-reference", "webclient-crud", "database"] },
   { label: "Develop", ids: ["getting-started", "project-structure", "technologies", "testing", "deployment"] },
 ] as const;
 

--- a/docs/wiki/api-reference.md
+++ b/docs/wiki/api-reference.md
@@ -88,6 +88,17 @@ All WebApi endpoints use EF Core via `IApplicationDbContext` for database operat
 public class Endpoint(IApplicationDbContext dbContext) : Endpoint<Request, Response>
 ```
 
+### WebClient response expectations
+
+The WebClient CRUD screens consume the REST endpoints through `src/WebClient/src/lib/api/webapi-client.ts` and normalize the response shapes used by the API:
+
+- list arrays, paginated objects, and `{ result: ... }` list envelopes
+- raw singular items with an `id`
+- `{ result: item }` singular envelopes
+- resource-key singular envelopes such as `{ organization: { ... } }`
+
+Relation lookups rely on that singular normalization before resolving table labels. When a visible row references a related record outside the first prefetched relation page, the client fetches the specific related item and merges it into the relation cache instead of overwriting previously fetched labels.
+
 ### Rate Limiting
 
 - 50 requests per minute per IP address

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -154,6 +154,9 @@ Implements data access with two strategies side by side:
 - Tailwind CSS with Catalyst-inspired product UI patterns implemented as resumable Qwik components
 - Static container runtime served by NGINX on port 5030
 - IdentityApi-backed login and bearer-token authorization for protected pages
+- Metadata-driven CRUD screens for all WebApi resources, with generated list/form fields, pagination, details panels, create/edit/delete actions, and relation-aware selects
+- Relation fields resolve readable labels from prefetched relation pages plus on-demand lookups for visible rows; fetched records are merged so off-page relation labels survive later prefetches
+- Edit forms prefill selected records, normalize date/datetime values for native inputs, and preserve selected relation IDs even when the related record is outside the prefetched option page
 
 ---
 

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -12,6 +12,7 @@ Cpnucleo is a project management and task tracking system built with .NET 10, de
 | [Getting Started](getting-started) | Prerequisites, build, run with Docker Compose or locally |
 | [Project Structure](project-structure) | Full tree of `src/` and `tests/` with descriptions |
 | [API Reference](api-reference) | WebApi endpoints, IdentityApi auth, GrpcServer contracts |
+| [WebClient CRUD](webclient-crud) | Qwik CRUD screens, edit-form prefill, relation labels, response normalization |
 | [Database](database) | PostgreSQL setup, EF Core, Dapper, init scripts |
 | [Testing](testing) | Architecture tests, unit tests, integration tests |
 | [Deployment](deployment) | Docker Compose configs, GitHub Actions CI/CD, NGINX |
@@ -30,7 +31,7 @@ Cpnucleo is a project management and task tracking system built with .NET 10, de
 - NGINX reverse proxy with least-connection load balancing across multiple WebApi instances
 - Docker Compose configurations for development, default, and production environments
 - AOT, Trim, and ExtraOptimize build options for production-optimized containers
-- Astro + Qwik frontend with Tailwind CSS, IdentityApi login, and CRUD screens for all WebApi resources
+- Astro + Qwik frontend with Tailwind CSS, IdentityApi login, and CRUD screens for all WebApi resources, including prefilled edit forms and readable relation labels
 - Automated CI/CD with GitHub Actions deploying to Hostinger Docker Manager via GHCR
 
 ---

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Cpnucleo has four test projects covering 27 architecture rules, 4 Application unit-test cases, 49 WebApi unit-test cases in source, and 55 integration tests. The active GitHub Actions gates run architecture tests and container health checks; unit/integration suites are kept for local/manual validation.
+Cpnucleo has five test projects covering the architecture rules plus source checks, 4 Application unit-test cases, 11 security unit-test cases, 53 WebApi unit-test cases in source, and 55 integration tests. The active GitHub Actions gates run architecture tests and container health checks; unit/integration suites are kept for local/manual validation.
 
 ---
 
@@ -9,6 +9,8 @@ Cpnucleo has four test projects covering 27 architecture rules, 4 Application un
 | Project | Framework | Focus | Key Libraries |
 |---------|-----------|-------|--------------|
 | Architecture.Tests | xUnit | Clean Architecture rules | NetArchTest.Rules, FluentAssertions |
+| Application.Unit.Tests | NUnit | Shared Application use cases | FakeItEasy, Shouldly |
+| Security.Unit.Tests | NUnit | Password hashing and login verification | Shouldly |
 | WebApi.Unit.Tests | NUnit | Endpoint unit tests | FakeItEasy, Shouldly, FastEndpoints |
 | WebApi.Integration.Tests | xUnit v3 | 55 endpoint integration tests | FastEndpoints.Testing, Shouldly |
 
@@ -71,7 +73,7 @@ These tests enforce Clean Architecture dependency rules at build time using NetA
 
 ## Unit Tests (`tests/WebApi.Unit.Tests/`)
 
-Unit tests for WebApi endpoints using NUnit with FakeItEasy for mocking and Shouldly for assertions. The source contains 49 test cases, but the suite is not part of the active CI gate and currently needs cleanup around several `Remove*` request-model references before it compiles end to end.
+Unit tests for WebApi endpoints using NUnit with FakeItEasy for mocking and Shouldly for assertions. The source contains 53 test cases, but the suite is not part of the active CI gate and currently needs cleanup around several `Remove*` request-model references before it compiles end to end.
 
 ### Structure
 
@@ -136,7 +138,18 @@ sleep 30
 
 ## Running Tests
 
-### Run All Tests
+### Run WebClient Tests
+
+```bash
+cd src/WebClient
+bun test
+bun run typecheck
+bun run build
+```
+
+The WebClient Vitest suite covers generated CRUD behaviors including edit-field date normalization, controlled relation selects, fallback selected relation options, readable relation labels, merged relation caches, and singular WebApi item response envelopes.
+
+### Run All .NET Tests
 
 ```bash
 dotnet test cpnucleo.slnx
@@ -180,4 +193,4 @@ Architecture tests run automatically in both CI workflows:
 - **build-check.yml** (PR): runs architecture tests for each service (WebApi, GrpcServer, IdentityApi, WebClient)
 - **main-release.yml** (push to main): runs architecture tests before building Docker images
 
-Unit and integration test projects remain available for local/manual runs; the active GitHub Actions gates run architecture tests and container health checks. Latest local audit: `Architecture.Tests` passes 27/27 and `Application.Unit.Tests` passes 4/4, while `WebApi.Unit.Tests` has compile drift around removed `Remove*.Request` model types.
+Unit and integration test projects remain available for local/manual runs; the active GitHub Actions gates run architecture tests and container health checks. Latest source audit: `Architecture.Tests` contains 55 test cases including the original 27 architecture-rule tests, `Application.Unit.Tests` contains 4, `Security.Unit.Tests` contains 11, and `WebApi.Unit.Tests` contains 53 test cases with known compile drift around removed `Remove*.Request` model types.

--- a/docs/wiki/webclient-crud.md
+++ b/docs/wiki/webclient-crud.md
@@ -1,0 +1,90 @@
+# WebClient CRUD
+
+The WebClient under `src/WebClient` is an Astro + Qwik frontend that exposes authenticated, Catalyst-inspired CRUD screens for the WebApi resources listed in `src/WebClient/src/lib/api/resource-metadata.ts`.
+
+---
+
+## Resource metadata
+
+`resource-metadata.ts` is the source of truth for each screen:
+
+- route path, singular label, plural label, and description
+- item and list API paths (`/api/{entity}` and `/api/{entities}` through the configured WebApi base URL)
+- table fields, form fields, required fields, and read-only fields
+- relation fields such as `projectId`, `workflowId`, `userId`, and `organizationId`
+
+The active resources are organizations, projects, assignments, assignment types, impediments, assignment impediments, appointments, workflows, users, user assignments, and user projects.
+
+---
+
+## List pages and relation labels
+
+`CrudPage` renders each list with pagination, details, edit, and delete actions. It also owns prefilled edit forms and relation fields are displayed as readable relation labels instead of raw GUIDs when the related record can be resolved.
+
+Relation resolution works in two passes:
+
+1. Prefetch the first 100 records for each relation used by the current resource.
+2. Scan the visible rows for missing related IDs and fetch those records on demand.
+
+Fetched relation records are merged, not replaced, so an on-demand lookup for an off-page relation is not lost when the first-page prefetch finishes later.
+
+Readable labels are produced by `displayEntityLabel`:
+
+| Related record shape | Display label |
+|----------------------|---------------|
+| `name` + different `description` | `Name — Description` |
+| `name` + different `login` | `Name (login)` |
+| only `name`, `description`, or `login` | that value |
+| unresolved relation | raw ID fallback |
+
+---
+
+## Create and edit forms
+
+Forms are generated from `formFields(resource)` and reuse the same metadata as list pages.
+
+Edit mode pre-fills controls from the selected row:
+
+- text, textarea, GUID, and number fields are converted to strings
+- `date` fields are normalized to `YYYY-MM-DD`
+- `datetime-local` fields are normalized to `YYYY-MM-DDTHH:mm`
+- relation selects are controlled by the selected row's relation ID
+
+A relation select is disabled only while its option collection is still loading. If the selected relation ID is outside the prefetched option page, the form keeps a fallback option for that ID so saving the edit does not accidentally drop the existing relationship.
+
+Empty optional GUID, number, date, and datetime fields are omitted from save payloads. Number fields are converted back to numbers before sending to the WebApi.
+
+---
+
+## WebApi response normalization
+
+The WebClient accepts the response shapes currently used by the WebApi:
+
+- list arrays
+- paginated list objects
+- `{ result: ... }` envelopes
+- singular item objects with `id`
+- singular `{ result: item }` envelopes
+- singular resource-key envelopes such as `{ organization: { ... } }`
+
+`normalizeItem` unwraps singular item envelopes before relation-label lookup code receives the record. This keeps relation labels readable even when an on-demand lookup returns an entity-specific envelope instead of the entity at the top level.
+
+---
+
+## Regression coverage
+
+The WebClient Vitest suite covers the CRUD behaviors that are easy to regress:
+
+- edit field value formatting for date and datetime controls
+- controlled relation select binding in edit forms
+- fallback selected relation options when the related record is not in the prefetched page
+- readable relation-label formatting and merged relation record caches
+- singular item response normalization across raw, `result`, and resource-key envelopes
+
+Run the WebClient gate from `src/WebClient`:
+
+```bash
+bun test
+bun run typecheck
+bun run build
+```

--- a/scripts/check-docs-drift.py
+++ b/scripts/check-docs-drift.py
@@ -97,8 +97,10 @@ def main() -> None:
     arch_tests = count_attrs("tests/Architecture.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
     unit_tests = count_attrs("tests/WebApi.Unit.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
     integration_tests = count_attrs("tests/WebApi.Integration.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
-    if (arch_tests, unit_tests, integration_tests) != (27, 49, 55):
-        fail(f"unexpected test counts: architecture={arch_tests}, unit={unit_tests}, integration={integration_tests}")
+    app_tests = count_attrs("tests/Application.Unit.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
+    security_tests = count_attrs("tests/Security.Unit.Tests", r"\[(?:[^\]]*,\s*)?(Fact|Theory|Test)(?:\s*[,\(\]])")
+    if (arch_tests, app_tests, security_tests, unit_tests, integration_tests) != (55, 4, 11, 53, 55):
+        fail(f"unexpected test counts: architecture={arch_tests}, application={app_tests}, security={security_tests}, webapi_unit={unit_tests}, integration={integration_tests}")
 
     endpoint_count = len(list((ROOT / "src/WebApi/Endpoints").glob("**/Endpoint.cs")))
     handler_count = len(list((ROOT / "src/GrpcServer/Handlers").glob("**/*Handler.cs")))
@@ -107,13 +109,19 @@ def main() -> None:
         fail(f"unexpected endpoint/handler/command counts: {endpoint_count}/{handler_count}/{command_count}")
 
     assert_contains("README.md", "27 architecture tests")
+    assert_contains("README.md", "Five test projects")
     assert_contains("README.md", "Pages documentation")
     assert_absent("README.md", "github.com/jonathanperis/cpnucleo/wiki")
     assert_absent("docs/wiki/getting-started.md", "http://localhost:5300/healthz")
     assert_contains("docs/wiki/getting-started.md", "http://localhost:5301/healthz")
     assert_contains("docs/wiki/api-reference.md", "gRPC transport: `http://localhost:5300` (HTTP/2)")
     assert_contains("docs/wiki/api-reference.md", "Health check: `http://localhost:5301/healthz` (HTTP/1.1)")
+    assert_contains("docs/wiki/api-reference.md", "resource-key singular envelopes")
+    assert_contains("docs/wiki/webclient-crud.md", "prefilled edit forms")
+    assert_contains("docs/wiki/webclient-crud.md", "readable relation labels")
+    assert_contains("docs/wiki/webclient-crud.md", "singular item response normalization")
     assert_contains("docs/wiki/testing.md", "55 integration tests")
+    assert_contains("docs/wiki/testing.md", "WebClient Vitest suite")
     assert_contains("docs/wiki/deployment.md", "Hostinger Docker Manager")
 
     print("README/wiki drift checks passed")


### PR DESCRIPTION
## Summary
- add a WebClient CRUD docs page covering resource metadata, edit-form prefill, relation label lookup, response normalization, and regression coverage
- link the new page from the Pages docs home/sidebar and update README/architecture/API/testing references
- refresh docs drift checks for the new page and current test-project counts

## Verification
- [x] `git diff --check`
- [x] `python scripts/check-docs-drift.py`
- [x] `bun run build` from `docs/`
- [x] `bun test && bun run typecheck && bun run build` from `src/WebClient`
